### PR TITLE
feat: annotation prompts list + editor

### DIFF
--- a/frontend/src/features/datasets/api/queries.test.tsx
+++ b/frontend/src/features/datasets/api/queries.test.tsx
@@ -4,7 +4,17 @@ import {
   createTestQueryClient,
   createTestWrapper,
 } from "../../../test-utils.tsx";
-import { dialogKeys, useCreateDialog, useDialogs } from "./queries.ts";
+import {
+  annotationPromptKeys,
+  dialogKeys,
+  ttsProviderKeys,
+  useAnnotationPrompt,
+  useAnnotationPrompts,
+  useCreateAnnotationPrompt,
+  useCreateDialog,
+  useDialogs,
+  useTtsProviders,
+} from "./queries.ts";
 
 const createdDialog = {
   id: 5,
@@ -14,6 +24,26 @@ const createdDialog = {
   created_by: null,
   created_at: "2026-04-03T10:00:00.000Z",
 };
+
+const createdPrompt = {
+  id: 7,
+  title: "Narration prompt",
+  provider_id: "google",
+  language: "en-US",
+  prompt: "Annotate this dialog for narration.",
+  created_by: null,
+  created_at: "2026-04-03T11:00:00.000Z",
+};
+
+const ttsProviders = [
+  {
+    id: "google",
+    name: "Google",
+    type: "tts" as const,
+    enabled: true,
+    created_at: "2026-04-03T09:00:00.000Z",
+  },
+];
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -30,7 +60,7 @@ function extractUrl(input: string | URL | Request): string {
   }
 
   if (input instanceof URL) {
-    return input.pathname;
+    return input.pathname + input.search;
   }
 
   return input.url;
@@ -38,9 +68,11 @@ function extractUrl(input: string | URL | Request): string {
 
 describe("datasets queries", () => {
   let dialogs = [createdDialog];
+  let prompts = [createdPrompt];
 
   beforeEach(() => {
     dialogs = [createdDialog];
+    prompts = [createdPrompt];
 
     vi.stubGlobal(
       "fetch",
@@ -65,6 +97,44 @@ describe("datasets queries", () => {
           };
           dialogs = [...dialogs, nextDialog];
           return jsonResponse(nextDialog, 201);
+        }
+
+        if (
+          url.endsWith("/api/annotation-prompts") &&
+          (!init?.method || init.method === "GET")
+        ) {
+          return jsonResponse(prompts);
+        }
+
+        if (
+          url.endsWith("/api/annotation-prompts/7") &&
+          (!init?.method || init.method === "GET")
+        ) {
+          return jsonResponse(createdPrompt);
+        }
+
+        if (url.endsWith("/api/annotation-prompts") && init?.method === "POST") {
+          const payload = JSON.parse(String(init.body)) as {
+            title: string;
+            provider_id: string;
+            language: string;
+            prompt: string;
+          };
+
+          const nextPrompt = {
+            ...createdPrompt,
+            id: 8,
+            title: payload.title,
+            provider_id: payload.provider_id,
+            language: payload.language,
+            prompt: payload.prompt,
+          };
+          prompts = [...prompts, nextPrompt];
+          return jsonResponse(nextPrompt, 201);
+        }
+
+        if (url.endsWith("/api/providers?type=tts")) {
+          return jsonResponse(ttsProviders);
         }
 
         return jsonResponse({ message: "Not Found" }, 404);
@@ -122,6 +192,96 @@ describe("datasets queries", () => {
     expect(queryClient.getQueryData(dialogKeys.list())).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ title: "Fresh dialog" }),
+      ]),
+    );
+  });
+
+  it("fetches annotation prompts and prompt detail", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestWrapper({ queryClient });
+
+    const { result: listResult } = renderHook(() => useAnnotationPrompts(), {
+      wrapper,
+    });
+    const { result: detailResult } = renderHook(() => useAnnotationPrompt(7), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(listResult.current.isSuccess).toBe(true);
+      expect(detailResult.current.isSuccess).toBe(true);
+    });
+
+    expect(listResult.current.data).toEqual(prompts);
+    expect(detailResult.current.data).toEqual(createdPrompt);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/annotation-prompts",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/annotation-prompts/7",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+  });
+
+  it("fetches TTS providers for prompt forms", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestWrapper({ queryClient });
+
+    const { result } = renderHook(() => useTtsProviders(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(ttsProviders);
+    expect(queryClient.getQueryData(ttsProviderKeys.list())).toEqual(ttsProviders);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/providers?type=tts",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+  });
+
+  it("invalidates the annotation prompt list after creating a prompt", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestWrapper({ queryClient });
+
+    const { result: promptsResult } = renderHook(() => useAnnotationPrompts(), {
+      wrapper,
+    });
+    const { result: mutationResult } = renderHook(
+      () => useCreateAnnotationPrompt(),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(promptsResult.current.isSuccess).toBe(true);
+    });
+
+    await act(async () => {
+      await mutationResult.current.mutateAsync({
+        title: "Fresh prompt",
+        provider_id: "google",
+        language: "en-US",
+        prompt: "Write pacing hints for each line.",
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(annotationPromptKeys.list())).toHaveLength(2);
+    });
+
+    expect(queryClient.getQueryData(annotationPromptKeys.list())).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ title: "Fresh prompt" }),
       ]),
     );
   });

--- a/frontend/src/features/datasets/api/queries.ts
+++ b/frontend/src/features/datasets/api/queries.ts
@@ -5,9 +5,11 @@ import {
 } from "@tanstack/react-query";
 import { api } from "../../../lib/api-client.ts";
 import type {
+  AnnotationPrompt,
   Dialog,
   DialogMessage,
   DialogWithMessages,
+  Provider,
 } from "../../../types/api.ts";
 
 export interface CreateDialogInput {
@@ -33,10 +35,35 @@ export interface UpdateMessageInput {
   text?: string;
 }
 
+export interface CreateAnnotationPromptInput {
+  title: string;
+  provider_id: string;
+  language: string;
+  prompt: string;
+}
+
+export interface UpdateAnnotationPromptInput {
+  title?: string;
+  provider_id?: string;
+  language?: string;
+  prompt?: string;
+}
+
 export const dialogKeys = {
   all: ["dialogs"] as const,
   list: () => [...dialogKeys.all, "list"] as const,
   detail: (dialogId: number) => [...dialogKeys.all, "detail", dialogId] as const,
+};
+
+export const annotationPromptKeys = {
+  all: ["annotation-prompts"] as const,
+  list: () => [...annotationPromptKeys.all, "list"] as const,
+  detail: (promptId: number) =>
+    [...annotationPromptKeys.all, "detail", promptId] as const,
+};
+
+export const ttsProviderKeys = {
+  list: () => ["providers", "tts"] as const,
 };
 
 async function fetchDialogs(): Promise<Dialog[]> {
@@ -45,6 +72,18 @@ async function fetchDialogs(): Promise<Dialog[]> {
 
 async function fetchDialog(dialogId: number): Promise<DialogWithMessages> {
   return api.get<DialogWithMessages>(`/dialogs/${dialogId}`);
+}
+
+async function fetchAnnotationPrompts(): Promise<AnnotationPrompt[]> {
+  return api.get<AnnotationPrompt[]>("/annotation-prompts");
+}
+
+async function fetchAnnotationPrompt(promptId: number): Promise<AnnotationPrompt> {
+  return api.get<AnnotationPrompt>(`/annotation-prompts/${promptId}`);
+}
+
+async function fetchTtsProviders(): Promise<Provider[]> {
+  return api.get<Provider[]>("/providers?type=tts");
 }
 
 export function useDialogs() {
@@ -59,6 +98,28 @@ export function useDialog(dialogId: number | null) {
     queryKey: dialogKeys.detail(dialogId ?? 0),
     queryFn: () => fetchDialog(dialogId!),
     enabled: dialogId !== null,
+  });
+}
+
+export function useAnnotationPrompts() {
+  return useQuery({
+    queryKey: annotationPromptKeys.list(),
+    queryFn: fetchAnnotationPrompts,
+  });
+}
+
+export function useAnnotationPrompt(promptId: number | null) {
+  return useQuery({
+    queryKey: annotationPromptKeys.detail(promptId ?? 0),
+    queryFn: () => fetchAnnotationPrompt(promptId!),
+    enabled: promptId !== null,
+  });
+}
+
+export function useTtsProviders() {
+  return useQuery({
+    queryKey: ttsProviderKeys.list(),
+    queryFn: fetchTtsProviders,
   });
 }
 
@@ -106,6 +167,61 @@ export function useDeleteDialog() {
         queryKey: dialogKeys.detail(variables.dialogId),
       });
       await queryClient.invalidateQueries({ queryKey: dialogKeys.list() });
+    },
+  });
+}
+
+export function useCreateAnnotationPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateAnnotationPromptInput) =>
+      api.post<AnnotationPrompt>("/annotation-prompts", input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: annotationPromptKeys.list(),
+      });
+    },
+  });
+}
+
+export function useUpdateAnnotationPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      promptId,
+      data,
+    }: {
+      promptId: number;
+      data: UpdateAnnotationPromptInput;
+    }) => api.put<AnnotationPrompt>(`/annotation-prompts/${promptId}`, data),
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: annotationPromptKeys.list(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: annotationPromptKeys.detail(variables.promptId),
+        }),
+      ]);
+    },
+  });
+}
+
+export function useDeleteAnnotationPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ promptId }: { promptId: number }) =>
+      api.delete(`/annotation-prompts/${promptId}`),
+    onSuccess: async (_, variables) => {
+      queryClient.removeQueries({
+        queryKey: annotationPromptKeys.detail(variables.promptId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: annotationPromptKeys.list(),
+      });
     },
   });
 }

--- a/frontend/src/features/datasets/components/DatasetsPage.test.tsx
+++ b/frontend/src/features/datasets/components/DatasetsPage.test.tsx
@@ -40,7 +40,7 @@ describe("DatasetsPage", () => {
       screen.getByRole("heading", { name: "Prompts" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Prompt management lands in the next task/i),
+      screen.getByText(/No prompts yet/i),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/datasets/components/DatasetsPage.tsx
+++ b/frontend/src/features/datasets/components/DatasetsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { DialogList } from "./DialogList.tsx";
+import { PromptList } from "./PromptList.tsx";
 
 type DatasetTab = "dialogs" | "prompts";
 
@@ -45,17 +46,7 @@ export function DatasetsPage() {
         </div>
       </div>
 
-      {activeTab === "dialogs" ? (
-        <DialogList />
-      ) : (
-        <section className="rounded-2xl border border-dashed border-gray-300 bg-white p-8 shadow-sm">
-          <h2 className="text-xl font-semibold text-gray-900">Prompts</h2>
-          <p className="mt-2 text-sm text-gray-600">
-            Prompt management lands in the next task. The tab is already wired
-            so the page structure stays stable.
-          </p>
-        </section>
-      )}
+      {activeTab === "dialogs" ? <DialogList /> : <PromptList />}
     </div>
   );
 }

--- a/frontend/src/features/datasets/components/PromptEditor.test.tsx
+++ b/frontend/src/features/datasets/components/PromptEditor.test.tsx
@@ -1,0 +1,213 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { annotationPromptKeys } from "../api/queries.ts";
+import { createTestQueryClient, renderWithProviders } from "../../../test-utils.tsx";
+import { PromptEditor } from "./PromptEditor.tsx";
+
+const providers = [
+  {
+    id: "google",
+    name: "Google",
+    type: "tts" as const,
+    enabled: true,
+    created_at: "2026-04-01T09:00:00.000Z",
+  },
+  {
+    id: "elevenlabs",
+    name: "ElevenLabs",
+    type: "tts" as const,
+    enabled: true,
+    created_at: "2026-04-01T09:30:00.000Z",
+  },
+];
+
+const initialPrompt = {
+  id: 1,
+  title: "Narration prompt",
+  provider_id: "google",
+  language: "en-US",
+  prompt: "Annotate each line for narration pacing.",
+  created_by: null,
+  created_at: "2026-04-01T10:00:00.000Z",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function noContentResponse() {
+  return new Response(null, { status: 204 });
+}
+
+function extractUrl(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname + input.search;
+  }
+
+  return input.url;
+}
+
+function renderPromptEditor(queryClient = createTestQueryClient()) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/datasets" element={<h1>Datasets Stub</h1>} />
+      <Route path="/datasets/prompts/:promptId" element={<PromptEditor />} />
+    </Routes>,
+    {
+      queryClient,
+      route: "/datasets/prompts/1",
+    },
+  );
+}
+
+describe("PromptEditor", () => {
+  let currentPrompt = initialPrompt;
+
+  beforeEach(() => {
+    currentPrompt = structuredClone(initialPrompt);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = extractUrl(input);
+
+        if (
+          url.endsWith("/api/annotation-prompts/1") &&
+          (!init?.method || init.method === "GET")
+        ) {
+          return jsonResponse(currentPrompt);
+        }
+
+        if (url.endsWith("/api/providers?type=tts")) {
+          return jsonResponse(providers);
+        }
+
+        if (url.endsWith("/api/annotation-prompts/1") && init?.method === "PUT") {
+          const payload = JSON.parse(String(init.body)) as {
+            title?: string;
+            provider_id?: string;
+            language?: string;
+            prompt?: string;
+          };
+
+          currentPrompt = {
+            ...currentPrompt,
+            title: payload.title ?? currentPrompt.title,
+            provider_id: payload.provider_id ?? currentPrompt.provider_id,
+            language: payload.language ?? currentPrompt.language,
+            prompt: payload.prompt ?? currentPrompt.prompt,
+          };
+
+          return jsonResponse(currentPrompt);
+        }
+
+        if (
+          url.endsWith("/api/annotation-prompts/1") &&
+          init?.method === "DELETE"
+        ) {
+          return noContentResponse();
+        }
+
+        return jsonResponse({ message: "Not Found" }, 404);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves unsaved edits when the detail query refetches", async () => {
+    const user = userEvent.setup();
+    const queryClient = createTestQueryClient();
+
+    renderPromptEditor(queryClient);
+
+    const titleInput = await screen.findByLabelText("Title");
+    await user.clear(titleInput);
+    await user.type(titleInput, "Unsaved local prompt title");
+
+    currentPrompt = {
+      ...currentPrompt,
+      title: "Server title after refetch",
+    };
+
+    await queryClient.refetchQueries({
+      queryKey: annotationPromptKeys.detail(1),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title")).toHaveValue(
+        "Unsaved local prompt title",
+      );
+    });
+  });
+
+  it("saves metadata and prompt body changes", async () => {
+    const user = userEvent.setup();
+
+    renderPromptEditor();
+
+    const titleInput = await screen.findByLabelText("Title");
+    await user.clear(titleInput);
+    await user.type(titleInput, "Saved prompt title");
+    await user.selectOptions(screen.getByLabelText("Language"), "en-GB");
+    await user.selectOptions(screen.getByLabelText("TTS Provider"), "elevenlabs");
+    await user.clear(screen.getByLabelText("Prompt body"));
+    await user.type(
+      screen.getByLabelText("Prompt body"),
+      "Write clearer pacing hints for each line.",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save Prompt" }));
+
+    expect(
+      await screen.findByText("Prompt saved."),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/annotation-prompts/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            title: "Saved prompt title",
+            language: "en-GB",
+            provider_id: "elevenlabs",
+            prompt: "Write clearer pacing hints for each line.",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("deletes the prompt and navigates back to datasets", async () => {
+    const user = userEvent.setup();
+    const confirmMock = vi.fn(() => true);
+    Object.defineProperty(window, "confirm", {
+      value: confirmMock,
+      writable: true,
+    });
+
+    renderPromptEditor();
+
+    await screen.findByRole("heading", { name: "Prompt Editor" });
+    await user.click(screen.getByRole("button", { name: "Delete Prompt" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Datasets Stub" }),
+    ).toBeInTheDocument();
+    expect(confirmMock).toHaveBeenCalledWith("Delete this prompt?");
+  });
+});

--- a/frontend/src/features/datasets/components/PromptEditor.tsx
+++ b/frontend/src/features/datasets/components/PromptEditor.tsx
@@ -1,0 +1,401 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import type { AnnotationPrompt, Provider } from "../../../types/api.ts";
+import {
+  useAnnotationPrompt,
+  useDeleteAnnotationPrompt,
+  useTtsProviders,
+  useUpdateAnnotationPrompt,
+} from "../api/queries.ts";
+
+const LANGUAGE_OPTIONS = [
+  { value: "en-US", label: "English (US)" },
+  { value: "en-GB", label: "English (UK)" },
+  { value: "de-DE", label: "German" },
+  { value: "fr-FR", label: "French" },
+  { value: "es-ES", label: "Spanish" },
+] as const;
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function getProviderOptions(
+  providers: Provider[],
+  currentProviderId: string,
+): Provider[] {
+  if (!currentProviderId || providers.some((provider) => provider.id === currentProviderId)) {
+    return providers;
+  }
+
+  return [
+    ...providers,
+    {
+      id: currentProviderId,
+      name: currentProviderId,
+      type: "tts",
+      enabled: false,
+      created_at: "",
+    },
+  ];
+}
+
+export function PromptEditor() {
+  const navigate = useNavigate();
+  const params = useParams();
+  const parsedPromptId = Number(params.promptId);
+  const promptId =
+    Number.isInteger(parsedPromptId) && parsedPromptId > 0
+      ? parsedPromptId
+      : null;
+
+  const promptQuery = useAnnotationPrompt(promptId);
+  const providersQuery = useTtsProviders();
+  const updatePrompt = useUpdateAnnotationPrompt();
+  const deletePrompt = useDeleteAnnotationPrompt();
+
+  const hydratedPromptIdRef = useRef<number | null>(null);
+  const [title, setTitle] = useState("");
+  const [language, setLanguage] = useState("en-US");
+  const [providerId, setProviderId] = useState("");
+  const [promptBody, setPromptBody] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formNotice, setFormNotice] = useState<string | null>(null);
+
+  function hydratePrompt(prompt: AnnotationPrompt) {
+    setTitle(prompt.title);
+    setLanguage(prompt.language);
+    setProviderId(prompt.provider_id);
+    setPromptBody(prompt.prompt);
+    setFormError(null);
+    setFormNotice(null);
+  }
+
+  useEffect(() => {
+    hydratedPromptIdRef.current = null;
+  }, [promptId]);
+
+  useEffect(() => {
+    if (!promptQuery.data || promptId === null) {
+      return;
+    }
+
+    if (hydratedPromptIdRef.current === promptId) {
+      return;
+    }
+
+    // The editor keeps a local draft separate from the query cache.
+    // This hydration runs only when switching to a different prompt.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    hydratePrompt(promptQuery.data);
+    hydratedPromptIdRef.current = promptId;
+  }, [promptId, promptQuery.data]);
+
+  function clearFeedback() {
+    if (formError) {
+      setFormError(null);
+    }
+    if (formNotice) {
+      setFormNotice(null);
+    }
+  }
+
+  async function handleSave() {
+    clearFeedback();
+
+    if (!promptId || !promptQuery.data) {
+      setFormError("Prompt not found.");
+      return;
+    }
+
+    const nextTitle = title.trim();
+    const nextLanguage = language.trim();
+    const nextProviderId = providerId.trim();
+
+    if (!nextTitle) {
+      setFormError("Title is required.");
+      return;
+    }
+
+    if (!nextLanguage) {
+      setFormError("Language is required.");
+      return;
+    }
+
+    if (!nextProviderId) {
+      setFormError("TTS provider is required.");
+      return;
+    }
+
+    try {
+      await updatePrompt.mutateAsync({
+        promptId,
+        data: {
+          title: nextTitle,
+          language: nextLanguage,
+          provider_id: nextProviderId,
+          prompt: promptBody,
+        },
+      });
+
+      const refreshedPrompt = await promptQuery.refetch();
+      if (refreshedPrompt.data) {
+        hydratePrompt(refreshedPrompt.data);
+        hydratedPromptIdRef.current = promptId;
+      }
+      setFormNotice("Prompt saved.");
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "Failed to save prompt.",
+      );
+    }
+  }
+
+  async function handleDeletePrompt() {
+    clearFeedback();
+
+    if (!promptId) {
+      return;
+    }
+
+    if (!window.confirm("Delete this prompt?")) {
+      return;
+    }
+
+    try {
+      await deletePrompt.mutateAsync({ promptId });
+      navigate("/datasets");
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "Failed to delete prompt.",
+      );
+    }
+  }
+
+  const isSaving = updatePrompt.isPending || deletePrompt.isPending;
+  const providerOptions = getProviderOptions(
+    providersQuery.data ?? [],
+    providerId,
+  );
+
+  if (promptId === null) {
+    return (
+      <div className="space-y-4">
+        <Link
+          className="text-sm font-medium text-gray-600 hover:text-gray-900"
+          to="/datasets"
+        >
+          Back to datasets
+        </Link>
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+          Invalid prompt id.
+        </div>
+      </div>
+    );
+  }
+
+  if (promptQuery.isPending) {
+    return (
+      <div className="space-y-4">
+        <Link
+          className="text-sm font-medium text-gray-600 hover:text-gray-900"
+          to="/datasets"
+        >
+          Back to datasets
+        </Link>
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">
+          Loading prompt...
+        </div>
+      </div>
+    );
+  }
+
+  if (promptQuery.isError || !promptQuery.data) {
+    return (
+      <div className="space-y-4">
+        <Link
+          className="text-sm font-medium text-gray-600 hover:text-gray-900"
+          to="/datasets"
+        >
+          Back to datasets
+        </Link>
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+          {promptQuery.error instanceof Error
+            ? promptQuery.error.message
+            : "Failed to load prompt."}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <Link
+            className="text-sm font-medium text-gray-600 hover:text-gray-900"
+            to="/datasets"
+          >
+            Back to datasets
+          </Link>
+          <h1 className="mt-2 text-2xl font-bold text-gray-900">Prompt Editor</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Created {formatTimestamp(promptQuery.data.created_at)}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            className="rounded-lg border border-red-200 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handleDeletePrompt}
+            disabled={isSaving}
+          >
+            Delete Prompt
+          </button>
+          <button
+            type="button"
+            className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handleSave}
+            disabled={isSaving}
+          >
+            {isSaving ? "Saving..." : "Save Prompt"}
+          </button>
+        </div>
+      </div>
+
+      {formError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {formError}
+        </div>
+      ) : null}
+
+      {formNotice ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          {formNotice}
+        </div>
+      ) : null}
+
+      {providersQuery.isError ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          Unable to refresh the TTS provider list right now. You can still keep
+          the current provider selection.
+        </div>
+      ) : null}
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="space-y-6">
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-900">Metadata</h2>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="flex flex-col gap-1 text-sm text-gray-600 md:col-span-2">
+                Title
+                <input
+                  type="text"
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                  value={title}
+                  onChange={(event) => {
+                    clearFeedback();
+                    setTitle(event.target.value);
+                  }}
+                  disabled={isSaving}
+                />
+              </label>
+
+              <label className="flex flex-col gap-1 text-sm text-gray-600">
+                Language
+                <select
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                  value={language}
+                  onChange={(event) => {
+                    clearFeedback();
+                    setLanguage(event.target.value);
+                  }}
+                  disabled={isSaving}
+                >
+                  {LANGUAGE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="flex flex-col gap-1 text-sm text-gray-600">
+                TTS Provider
+                <select
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                  value={providerId}
+                  onChange={(event) => {
+                    clearFeedback();
+                    setProviderId(event.target.value);
+                  }}
+                  disabled={isSaving || providersQuery.isPending}
+                >
+                  <option value="">Select a provider</option>
+                  {providerOptions.map((provider) => (
+                    <option key={provider.id} value={provider.id}>
+                      {provider.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-900">Prompt Body</h2>
+            <p className="mt-1 text-sm text-gray-600">
+              Write the annotation instructions exactly as they should be sent
+              to the model.
+            </p>
+
+            <label className="mt-4 flex flex-col gap-1 text-sm text-gray-600">
+              Prompt body
+              <textarea
+                className="min-h-64 rounded-lg border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900"
+                value={promptBody}
+                onChange={(event) => {
+                  clearFeedback();
+                  setPromptBody(event.target.value);
+                }}
+                disabled={isSaving}
+              />
+            </label>
+          </div>
+        </div>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+              Summary
+            </h2>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <dt className="text-gray-500">Prompt ID</dt>
+                <dd className="font-medium text-gray-900">{promptQuery.data.id}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <dt className="text-gray-500">Language</dt>
+                <dd className="font-medium text-gray-900">{language || "-"}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <dt className="text-gray-500">Provider</dt>
+                <dd className="font-medium text-gray-900">{providerId || "-"}</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/datasets/components/PromptList.test.tsx
+++ b/frontend/src/features/datasets/components/PromptList.test.tsx
@@ -1,0 +1,142 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../../test-utils.tsx";
+import { PromptList } from "./PromptList.tsx";
+
+const prompts = [
+  {
+    id: 1,
+    title: "Narration prompt",
+    provider_id: "google",
+    language: "en-US",
+    prompt: "Annotate this dialog for narration.",
+    created_by: null,
+    created_at: "2026-04-01T10:00:00.000Z",
+  },
+  {
+    id: 2,
+    title: "Support prompt",
+    provider_id: "elevenlabs",
+    language: "en-GB",
+    prompt: "Add pacing notes to each line.",
+    created_by: null,
+    created_at: "2026-04-02T10:00:00.000Z",
+  },
+];
+
+const providers = [
+  {
+    id: "google",
+    name: "Google",
+    type: "tts" as const,
+    enabled: true,
+    created_at: "2026-04-01T09:00:00.000Z",
+  },
+  {
+    id: "elevenlabs",
+    name: "ElevenLabs",
+    type: "tts" as const,
+    enabled: true,
+    created_at: "2026-04-01T09:30:00.000Z",
+  },
+];
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function extractUrl(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname + input.search;
+  }
+
+  return input.url;
+}
+
+function renderPromptList() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/datasets" element={<PromptList />} />
+      <Route path="/datasets/prompts/:promptId" element={<h1>Prompt Editor Stub</h1>} />
+    </Routes>,
+    { route: "/datasets" },
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = extractUrl(input);
+
+      if (
+        url.endsWith("/api/annotation-prompts") &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return jsonResponse(prompts);
+      }
+
+      if (url.endsWith("/api/providers?type=tts")) {
+        return jsonResponse(providers);
+      }
+
+      if (url.endsWith("/api/annotation-prompts") && init?.method === "POST") {
+        return jsonResponse(
+          {
+            id: 99,
+            title: "Untitled prompt",
+            provider_id: "google",
+            language: "en-US",
+            prompt: "",
+            created_by: null,
+            created_at: "2026-04-03T10:00:00.000Z",
+          },
+          201,
+        );
+      }
+
+      return jsonResponse({ message: "Not Found" }, 404);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("PromptList", () => {
+  it("renders prompts from the API with provider names", async () => {
+    renderPromptList();
+
+    expect(
+      await screen.findByRole("link", { name: "Support prompt" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Narration prompt" })).toBeInTheDocument();
+    expect(screen.getByText("ElevenLabs")).toBeInTheDocument();
+    expect(screen.getByText("Google")).toBeInTheDocument();
+  });
+
+  it("creates a prompt and navigates to the editor", async () => {
+    const user = userEvent.setup();
+
+    renderPromptList();
+
+    await screen.findByRole("button", { name: "New Prompt" });
+    await user.click(screen.getByRole("button", { name: "New Prompt" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Prompt Editor Stub" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/datasets/components/PromptList.tsx
+++ b/frontend/src/features/datasets/components/PromptList.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
+import type { AnnotationPrompt } from "../../../types/api.ts";
+import {
+  useAnnotationPrompts,
+  useCreateAnnotationPrompt,
+  useTtsProviders,
+} from "../api/queries.ts";
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+  }).format(date);
+}
+
+function sortPrompts(prompts: AnnotationPrompt[]): AnnotationPrompt[] {
+  return [...prompts].sort((left, right) =>
+    right.created_at.localeCompare(left.created_at),
+  );
+}
+
+export function PromptList() {
+  const navigate = useNavigate();
+  const promptsQuery = useAnnotationPrompts();
+  const providersQuery = useTtsProviders();
+  const createPrompt = useCreateAnnotationPrompt();
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const providers = providersQuery.data ?? [];
+  const providerNameById = new Map(
+    providers.map((provider) => [provider.id, provider.name]),
+  );
+  const prompts = promptsQuery.data ? sortPrompts(promptsQuery.data) : [];
+  const canCreatePrompt =
+    !createPrompt.isPending &&
+    !providersQuery.isPending &&
+    !providersQuery.isError &&
+    providers.length > 0;
+
+  async function handleCreatePrompt() {
+    setCreateError(null);
+
+    const providerId = providers[0]?.id;
+    if (!providerId) {
+      setCreateError("Add at least one TTS provider before creating prompts.");
+      return;
+    }
+
+    try {
+      const prompt = await createPrompt.mutateAsync({
+        title: "Untitled prompt",
+        provider_id: providerId,
+        language: "en-US",
+        prompt: "",
+      });
+      navigate(`/datasets/prompts/${prompt.id}`);
+    } catch (error) {
+      setCreateError(
+        error instanceof Error ? error.message : "Failed to create prompt.",
+      );
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Prompts</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Manage annotation prompt templates and keep them aligned with your
+            TTS providers.
+          </p>
+          {!providersQuery.isPending && providers.length === 0 ? (
+            <p className="mt-2 text-sm text-amber-700">
+              Add a TTS provider on the Providers page before creating prompts.
+            </p>
+          ) : null}
+        </div>
+
+        <button
+          type="button"
+          className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleCreatePrompt}
+          disabled={!canCreatePrompt}
+        >
+          {createPrompt.isPending ? "Creating..." : "New Prompt"}
+        </button>
+      </div>
+
+      {createError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {createError}
+        </div>
+      ) : null}
+
+      {promptsQuery.isPending ? (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">
+          Loading prompts...
+        </div>
+      ) : null}
+
+      {promptsQuery.isError ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+          {promptsQuery.error instanceof Error
+            ? promptsQuery.error.message
+            : "Failed to load prompts."}
+        </div>
+      ) : null}
+
+      {!promptsQuery.isPending && !promptsQuery.isError && prompts.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-sm text-gray-600 shadow-sm">
+          No prompts yet. Create the first one to start annotating dialogs.
+        </div>
+      ) : null}
+
+      {!promptsQuery.isPending &&
+      !promptsQuery.isError &&
+      prompts.length > 0 ? (
+        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-3">Title</th>
+                <th className="px-4 py-3">Language</th>
+                <th className="px-4 py-3">TTS Provider</th>
+                <th className="px-4 py-3">Date</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {prompts.map((prompt) => (
+                <tr key={prompt.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-4">
+                    <Link
+                      to={`/datasets/prompts/${prompt.id}`}
+                      className="font-medium text-gray-900 underline-offset-2 hover:underline"
+                    >
+                      {prompt.title}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-4 text-sm text-gray-600">
+                    {prompt.language}
+                  </td>
+                  <td className="px-4 py-4 text-sm text-gray-600">
+                    {providerNameById.get(prompt.provider_id) ?? prompt.provider_id}
+                  </td>
+                  <td className="px-4 py-4 text-sm text-gray-600">
+                    {formatDate(prompt.created_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -36,6 +36,18 @@ const dialogDetailResponse = {
   ],
 };
 
+const promptsResponse = [
+  {
+    id: 1,
+    title: "Narration prompt",
+    provider_id: "google",
+    language: "en-US",
+    prompt: "Annotate this dialog for narration pacing.",
+    created_by: null,
+    created_at: "2026-04-06T18:30:00.000Z",
+  },
+];
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -91,8 +103,24 @@ beforeEach(() => {
         return jsonResponse(dialogDetailResponse);
       }
 
+      if (url.endsWith("/api/annotation-prompts")) {
+        return jsonResponse(promptsResponse);
+      }
+
+      if (url.endsWith("/api/annotation-prompts/1")) {
+        return jsonResponse(promptsResponse[0]);
+      }
+
       if (url.includes("/api/providers?type=")) {
-        return jsonResponse([]);
+        return jsonResponse([
+          {
+            id: "google",
+            name: "Google",
+            type: "tts",
+            enabled: true,
+            created_at: "2026-04-06T17:00:00.000Z",
+          },
+        ]);
       }
 
       return jsonResponse(
@@ -136,6 +164,15 @@ describe("Router", () => {
         await screen.findByRole("heading", { name: "Dialog Editor" }),
       ).toBeInTheDocument();
       expect(screen.getByDisplayValue("Greeting practice")).toBeInTheDocument();
+    });
+
+    it("renders Prompt Editor page at /datasets/prompts/:promptId", async () => {
+      renderWithRouter(["/datasets/prompts/1"]);
+
+      expect(
+        await screen.findByRole("heading", { name: "Prompt Editor" }),
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Narration prompt")).toBeInTheDocument();
     });
 
     it("renders TTS Testing page at /tts", () => {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { AppLayout } from "./components/layout/AppLayout.tsx";
 import { DatasetsPage } from "./features/datasets/components/DatasetsPage.tsx";
 import { DialogEditor } from "./features/datasets/components/DialogEditor.tsx";
+import { PromptEditor } from "./features/datasets/components/PromptEditor.tsx";
 import { TtsPage } from "./pages/TtsPage.tsx";
 import { RealtimePage } from "./pages/RealtimePage.tsx";
 import { ProvidersPage } from "./pages/ProvidersPage.tsx";
@@ -13,6 +14,7 @@ export function AppRouteTree() {
         <Route index element={<Navigate to="/datasets" replace />} />
         <Route path="datasets" element={<DatasetsPage />} />
         <Route path="datasets/dialogs/:dialogId" element={<DialogEditor />} />
+        <Route path="datasets/prompts/:promptId" element={<PromptEditor />} />
         <Route path="tts" element={<TtsPage />} />
         <Route path="realtime" element={<RealtimePage />} />
         <Route path="providers" element={<ProvidersPage />} />


### PR DESCRIPTION
## Summary
- add datasets query hooks for annotation prompts CRUD plus local TTS provider loading
- implement the Prompts tab list with loading, empty, error, and create flows
- add a prompt editor route with save/delete actions and wire it into the datasets router/tests

## Testing
- `npm run test --workspace=frontend`
- `npm run lint --workspace=frontend`

Closes #25