### PR TITLE
feat: add Gemini realtime provider

### DIFF
--- a/backend/src/providers/realtime/gemini.ts
+++ b/backend/src/providers/realtime/gemini.ts
@@ -5,6 +5,7 @@ const GEMINI_REALTIME_URL =
   'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
 const GEMINI_MODELS_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
 const GEMINI_AUDIO_MIME_TYPE = 'audio/pcm;rate=16000';
+const SESSION_CLOSE_TIMEOUT_MS = 5000;
 
 interface GeminiModelRecord {
   name?: string;
@@ -112,11 +113,8 @@ function getLiveModelName(model: GeminiModelRecord): string | null {
   const methods = Array.isArray(model.supportedGenerationMethods)
     ? model.supportedGenerationMethods
     : [];
-  const supportsRealtime = methods.includes('bidiGenerateContent');
-  const looksLikeLiveModel = candidate.toLowerCase().includes('live')
-    || String(model.displayName ?? '').toLowerCase().includes('live');
 
-  return supportsRealtime || looksLikeLiveModel ? candidate : null;
+  return methods.includes('bidiGenerateContent') ? candidate : null;
 }
 
 async function readErrorResponse(response: Response, fallback: string): Promise<string> {
@@ -177,6 +175,56 @@ function buildSetupMessage(config: RealtimeSessionConfig): Record<string, unknow
   }
 
   return { setup };
+}
+
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  if (socket.readyState >= WebSocket.CLOSING) {
+    return;
+  }
+
+  socket.close(code, reason);
+}
+
+function waitForSocketClose(socket: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (): void => {
+      if (resolved) {
+        return;
+      }
+
+      resolved = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      resolve();
+    };
+
+    socket.once('close', () => {
+      finish();
+    });
+
+    timeoutHandle = setTimeout(() => {
+      if ('terminate' in socket && typeof socket.terminate === 'function') {
+        socket.terminate();
+      }
+
+      finish();
+    }, SESSION_CLOSE_TIMEOUT_MS);
+  });
+}
+
+function extractGoAwayEvent(goAway: Record<string, unknown>): RealtimeEvent {
+  const message = typeof goAway.message === 'string'
+    ? goAway.message
+    : 'Gemini Live API requested session shutdown';
+
+  return createErrorEvent(message, {
+    source: 'gemini',
+    timeLeft: typeof goAway.timeLeft === 'string' ? goAway.timeLeft : undefined,
+  });
 }
 
 function emitServerContent(
@@ -261,11 +309,7 @@ class GeminiRealtimeSession implements IRealtimeSession {
       return this.closePromise;
     }
 
-    this.closePromise = new Promise((resolve) => {
-      this.socket.once('close', () => {
-        resolve();
-      });
-    });
+    this.closePromise = waitForSocketClose(this.socket);
 
     if (this.socket.readyState === WebSocket.OPEN) {
       await sendJson(this.socket, {
@@ -277,9 +321,7 @@ class GeminiRealtimeSession implements IRealtimeSession {
       });
     }
 
-    if (this.socket.readyState < WebSocket.CLOSING) {
-      this.socket.close(1000, 'Session closed');
-    }
+    closeSocket(this.socket, 1000, 'Session closed');
 
     return this.closePromise;
   }
@@ -374,12 +416,15 @@ export class GeminiRealtimeProvider implements IRealtimeProvider {
         reject(payload as Error);
       };
 
+      const failStartup = (message: string): void => {
+        suppressRemoteSessionEnd();
+        settleStartup('reject', new Error(message));
+        closeSocket(socket, 1011, message);
+      };
+
       socket.on('open', () => {
         void sendJson(socket, buildSetupMessage(config)).catch((error) => {
-          settleStartup(
-            'reject',
-            new Error(getErrorMessage(error, 'Failed to configure Gemini realtime session')),
-          );
+          failStartup(getErrorMessage(error, 'Failed to configure Gemini realtime session'));
         });
       });
 
@@ -408,10 +453,17 @@ export class GeminiRealtimeProvider implements IRealtimeProvider {
         }
 
         if (isRecord(message.goAway)) {
-          const reason = typeof message.goAway.timeLeft === 'string'
-            ? message.goAway.timeLeft
-            : 'Gemini Live API requested session shutdown';
-          onEvent(createErrorEvent(reason, { source: 'gemini' }));
+          const goAwayEvent = extractGoAwayEvent(message.goAway);
+          onEvent(goAwayEvent);
+
+          if (!startupSettled) {
+            const payload = isRecord(goAwayEvent.data) ? goAwayEvent.data : null;
+            failStartup(
+              typeof payload?.message === 'string'
+                ? payload.message
+                : 'Gemini Live API requested session shutdown',
+            );
+          }
         }
       });
 
@@ -420,7 +472,7 @@ export class GeminiRealtimeProvider implements IRealtimeProvider {
         onEvent(createErrorEvent(message, { source: 'gemini' }));
 
         if (!startupSettled) {
-          settleStartup('reject', new Error(message));
+          failStartup(message);
         }
       });
 

--- a/backend/src/providers/realtime/gemini.ts
+++ b/backend/src/providers/realtime/gemini.ts
@@ -1,0 +1,452 @@
+import WebSocket, { type RawData } from 'ws';
+import type { IRealtimeProvider, IRealtimeSession, RealtimeEvent, RealtimeSessionConfig } from './types.js';
+
+const GEMINI_REALTIME_URL =
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
+const GEMINI_MODELS_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+const GEMINI_AUDIO_MIME_TYPE = 'audio/pcm;rate=16000';
+
+interface GeminiModelRecord {
+  name?: string;
+  baseModelId?: string;
+  displayName?: string;
+  supportedGenerationMethods?: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toBuffer(raw: RawData): Buffer {
+  if (typeof raw === 'string') {
+    return Buffer.from(raw);
+  }
+
+  if (raw instanceof ArrayBuffer) {
+    return Buffer.from(raw);
+  }
+
+  if (Array.isArray(raw)) {
+    return Buffer.concat(raw.map((chunk) => toBuffer(chunk)));
+  }
+
+  return Buffer.from(raw);
+}
+
+function parseJsonMessage(raw: RawData): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(toBuffer(raw).toString());
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function createErrorEvent(message: string, details?: Record<string, unknown>): RealtimeEvent {
+  return {
+    type: 'error',
+    data: {
+      message,
+      ...details,
+    },
+  };
+}
+
+function createTranscriptEvent(
+  role: 'user' | 'assistant',
+  text: string,
+  final = true,
+): RealtimeEvent {
+  return {
+    type: 'transcript',
+    data: {
+      role,
+      text,
+      final,
+    },
+  };
+}
+
+function createAudioEvent(data: string, mimeType?: string): RealtimeEvent {
+  return {
+    type: 'audio',
+    data: {
+      chunk: data,
+      mimeType: mimeType ?? GEMINI_AUDIO_MIME_TYPE,
+    },
+  };
+}
+
+async function sendJson(socket: WebSocket, payload: Record<string, unknown>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    socket.send(JSON.stringify(payload), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function normalizeModelName(name: string): string {
+  return name.startsWith('models/') ? name.slice('models/'.length) : name;
+}
+
+function getLiveModelName(model: GeminiModelRecord): string | null {
+  const candidate = typeof model.baseModelId === 'string'
+    ? model.baseModelId
+    : typeof model.name === 'string'
+      ? normalizeModelName(model.name)
+      : null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  const methods = Array.isArray(model.supportedGenerationMethods)
+    ? model.supportedGenerationMethods
+    : [];
+  const supportsRealtime = methods.includes('bidiGenerateContent');
+  const looksLikeLiveModel = candidate.toLowerCase().includes('live')
+    || String(model.displayName ?? '').toLowerCase().includes('live');
+
+  return supportsRealtime || looksLikeLiveModel ? candidate : null;
+}
+
+async function readErrorResponse(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = await response.clone().json();
+    if (isRecord(body) && typeof body.error === 'object' && body.error !== null) {
+      const error = body.error as Record<string, unknown>;
+      if (typeof error.message === 'string') {
+        return error.message;
+      }
+    }
+
+    if (isRecord(body) && typeof body.message === 'string') {
+      return body.message;
+    }
+  } catch {
+    // Ignore JSON parsing failures and fall back to raw text.
+  }
+
+  try {
+    const text = await response.clone().text();
+    if (text.trim()) {
+      return text;
+    }
+  } catch {
+    // Ignore text parsing failures.
+  }
+
+  return fallback;
+}
+
+function buildSetupMessage(config: RealtimeSessionConfig): Record<string, unknown> {
+  const generationConfig: Record<string, unknown> = {
+    responseModalities: ['AUDIO'],
+  };
+
+  if (config.voice) {
+    generationConfig.speechConfig = {
+      voiceConfig: {
+        prebuiltVoiceConfig: {
+          voiceName: config.voice,
+        },
+      },
+    };
+  }
+
+  const setup: Record<string, unknown> = {
+    model: `models/${normalizeModelName(config.model)}`,
+    generationConfig,
+    inputAudioTranscription: {},
+    outputAudioTranscription: {},
+  };
+
+  if (config.systemPrompt) {
+    setup.systemInstruction = {
+      parts: [{ text: config.systemPrompt }],
+    };
+  }
+
+  return { setup };
+}
+
+function emitServerContent(
+  serverContent: Record<string, unknown>,
+  onEvent: (event: RealtimeEvent) => void,
+): void {
+  const inputTranscription = isRecord(serverContent.inputTranscription)
+    ? serverContent.inputTranscription
+    : null;
+  if (typeof inputTranscription?.text === 'string' && inputTranscription.text) {
+    onEvent(createTranscriptEvent('user', inputTranscription.text));
+  }
+
+  const outputTranscription = isRecord(serverContent.outputTranscription)
+    ? serverContent.outputTranscription
+    : null;
+  if (typeof outputTranscription?.text === 'string' && outputTranscription.text) {
+    onEvent(createTranscriptEvent('assistant', outputTranscription.text));
+  }
+
+  const modelTurn = isRecord(serverContent.modelTurn) ? serverContent.modelTurn : null;
+  const parts = Array.isArray(modelTurn?.parts) ? modelTurn.parts : [];
+
+  for (const part of parts) {
+    if (!isRecord(part)) {
+      continue;
+    }
+
+    const inlineData = isRecord(part.inlineData) ? part.inlineData : null;
+    if (typeof inlineData?.data === 'string' && inlineData.data) {
+      onEvent(createAudioEvent(
+        inlineData.data,
+        typeof inlineData.mimeType === 'string' ? inlineData.mimeType : undefined,
+      ));
+      continue;
+    }
+
+    if (!outputTranscription && typeof part.text === 'string' && part.text) {
+      onEvent(createTranscriptEvent(
+        'assistant',
+        part.text,
+        typeof serverContent.turnComplete === 'boolean' ? serverContent.turnComplete : true,
+      ));
+    }
+  }
+}
+
+class GeminiRealtimeSession implements IRealtimeSession {
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly suppressRemoteSessionEnd: () => void,
+  ) {}
+
+  async sendAudio(chunk: Buffer): Promise<void> {
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('Gemini Realtime session is not open');
+    }
+
+    await sendJson(this.socket, {
+      realtimeInput: {
+        audio: {
+          data: chunk.toString('base64'),
+          mimeType: GEMINI_AUDIO_MIME_TYPE,
+        },
+      },
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closed = true;
+    this.suppressRemoteSessionEnd();
+
+    if (this.socket.readyState === WebSocket.CLOSED) {
+      this.closePromise = Promise.resolve();
+      return this.closePromise;
+    }
+
+    this.closePromise = new Promise((resolve) => {
+      this.socket.once('close', () => {
+        resolve();
+      });
+    });
+
+    if (this.socket.readyState === WebSocket.OPEN) {
+      await sendJson(this.socket, {
+        realtimeInput: {
+          audioStreamEnd: true,
+        },
+      }).catch(() => {
+        // Best effort flush before shutdown.
+      });
+    }
+
+    if (this.socket.readyState < WebSocket.CLOSING) {
+      this.socket.close(1000, 'Session closed');
+    }
+
+    return this.closePromise;
+  }
+}
+
+export class GeminiRealtimeProvider implements IRealtimeProvider {
+  readonly id = 'gemini-realtime';
+  readonly name = 'Gemini Realtime';
+
+  constructor(private readonly apiKey: string) {}
+
+  async getModels(): Promise<string[]> {
+    const models = new Set<string>();
+    let pageToken: string | null = null;
+
+    do {
+      const url = new URL(GEMINI_MODELS_URL);
+      url.searchParams.set('key', this.apiKey);
+      url.searchParams.set('pageSize', '1000');
+
+      if (pageToken) {
+        url.searchParams.set('pageToken', pageToken);
+      }
+
+      const response = await fetch(url.toString());
+      if (!response.ok) {
+        const message = await readErrorResponse(
+          response,
+          `Gemini models API error (${response.status})`,
+        );
+        throw new Error(`Gemini models API error: ${message}`);
+      }
+
+      const body = await response.json();
+      if (!isRecord(body)) {
+        throw new Error('Gemini models API returned an invalid response');
+      }
+
+      const pageModels = Array.isArray(body.models) ? body.models : [];
+      for (const model of pageModels) {
+        if (!isRecord(model)) {
+          continue;
+        }
+
+        const liveModel = getLiveModelName(model);
+        if (liveModel) {
+          models.add(liveModel);
+        }
+      }
+
+      pageToken = typeof body.nextPageToken === 'string' && body.nextPageToken
+        ? body.nextPageToken
+        : null;
+    } while (pageToken);
+
+    return [...models].sort();
+  }
+
+  async createSession(
+    config: RealtimeSessionConfig,
+    onEvent: (event: RealtimeEvent) => void,
+  ): Promise<IRealtimeSession> {
+    const url = new URL(GEMINI_REALTIME_URL);
+    url.searchParams.set('key', this.apiKey);
+
+    const socket = new WebSocket(url);
+
+    let session: GeminiRealtimeSession | null = null;
+    let startupSettled = false;
+    let remoteSessionEndEnabled = true;
+
+    const suppressRemoteSessionEnd = (): void => {
+      remoteSessionEndEnabled = false;
+    };
+
+    return new Promise<IRealtimeSession>((resolve, reject) => {
+      const settleStartup = (
+        kind: 'resolve' | 'reject',
+        payload: IRealtimeSession | Error,
+      ): void => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+
+        if (kind === 'resolve') {
+          resolve(payload as IRealtimeSession);
+          return;
+        }
+
+        reject(payload as Error);
+      };
+
+      socket.on('open', () => {
+        void sendJson(socket, buildSetupMessage(config)).catch((error) => {
+          settleStartup(
+            'reject',
+            new Error(getErrorMessage(error, 'Failed to configure Gemini realtime session')),
+          );
+        });
+      });
+
+      socket.on('message', (rawMessage) => {
+        const message = parseJsonMessage(rawMessage);
+        if (!message) {
+          onEvent(createErrorEvent(
+            'Invalid JSON event received from Gemini Live API',
+            { source: 'gemini' },
+          ));
+          return;
+        }
+
+        if ('setupComplete' in message) {
+          if (!session) {
+            session = new GeminiRealtimeSession(socket, suppressRemoteSessionEnd);
+          }
+
+          settleStartup('resolve', session);
+          return;
+        }
+
+        if (isRecord(message.serverContent)) {
+          emitServerContent(message.serverContent, onEvent);
+          return;
+        }
+
+        if (isRecord(message.goAway)) {
+          const reason = typeof message.goAway.timeLeft === 'string'
+            ? message.goAway.timeLeft
+            : 'Gemini Live API requested session shutdown';
+          onEvent(createErrorEvent(reason, { source: 'gemini' }));
+        }
+      });
+
+      socket.on('error', (error) => {
+        const message = getErrorMessage(error, 'Gemini websocket error');
+        onEvent(createErrorEvent(message, { source: 'gemini' }));
+
+        if (!startupSettled) {
+          settleStartup('reject', new Error(message));
+        }
+      });
+
+      socket.on('close', (code, reason) => {
+        const closeReason = toBuffer(reason).toString();
+
+        if (!startupSettled) {
+          settleStartup(
+            'reject',
+            new Error(
+              closeReason || `Gemini websocket closed before session was ready (${code})`,
+            ),
+          );
+          return;
+        }
+
+        if (remoteSessionEndEnabled) {
+          onEvent({
+            type: 'session_end',
+            data: {
+              code,
+              reason: closeReason,
+            },
+          });
+        }
+      });
+    });
+  }
+}

--- a/backend/src/providers/realtime/registry.ts
+++ b/backend/src/providers/realtime/registry.ts
@@ -1,8 +1,11 @@
 import type { IRealtimeProvider } from './types.js';
+import { GeminiRealtimeProvider } from './gemini.js';
 
 export type RealtimeProviderConstructor = new (apiKey: string) => IRealtimeProvider;
 
-const PROVIDERS: Record<string, RealtimeProviderConstructor> = {};
+const PROVIDERS: Record<string, RealtimeProviderConstructor> = {
+  'gemini-realtime': GeminiRealtimeProvider,
+};
 
 export function createRealtimeProvider(providerId: string, apiKey: string): IRealtimeProvider {
   const Provider = PROVIDERS[providerId];

--- a/backend/src/providers/realtime/registry.ts
+++ b/backend/src/providers/realtime/registry.ts
@@ -3,9 +3,7 @@ import { GeminiRealtimeProvider } from './gemini.js';
 
 export type RealtimeProviderConstructor = new (apiKey: string) => IRealtimeProvider;
 
-const PROVIDERS: Record<string, RealtimeProviderConstructor> = {
-  'gemini-realtime': GeminiRealtimeProvider,
-};
+const PROVIDERS: Record<string, RealtimeProviderConstructor> = {};
 
 export function createRealtimeProvider(providerId: string, apiKey: string): IRealtimeProvider {
   const Provider = PROVIDERS[providerId];
@@ -27,3 +25,5 @@ export function registerRealtimeProvider(
 export function getSupportedRealtimeProviders(): string[] {
   return Object.keys(PROVIDERS);
 }
+
+registerRealtimeProvider('gemini-realtime', GeminiRealtimeProvider);

--- a/backend/tests/providers/gemini-realtime.test.ts
+++ b/backend/tests/providers/gemini-realtime.test.ts
@@ -113,6 +113,7 @@ describe('GeminiRealtimeProvider', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('has the expected id and name', () => {
@@ -143,7 +144,6 @@ describe('GeminiRealtimeProvider', () => {
     }));
 
     await expect(provider.getModels()).resolves.toEqual([
-      'gemini-2.5-flash-live-preview',
       'gemini-3.1-flash-live-preview',
     ]);
 
@@ -211,6 +211,36 @@ describe('GeminiRealtimeProvider', () => {
       },
     });
     expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('closes the socket when startup setup send fails', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      send: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      open(): void;
+    };
+
+    socket.send.mockImplementationOnce((_data: string, callback?: (error?: Error) => void) => {
+      callback?.(new Error('setup failed'));
+      return true;
+    });
+
+    socket.open();
+
+    await expect(sessionPromise).rejects.toThrow('setup failed');
+    expect(socket.close).toHaveBeenCalledWith(1011, 'setup failed');
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
   });
 
   it('maps Gemini server messages into RealtimeEvent payloads', async () => {
@@ -318,6 +348,42 @@ describe('GeminiRealtimeProvider', () => {
     ]);
   });
 
+  it('reports goAway with a stable message and preserves timeLeft metadata', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be helpful',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ setupComplete: {} });
+
+    await sessionPromise;
+
+    socket.emitMessage({
+      goAway: {
+        timeLeft: '10s',
+      },
+    });
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'error',
+      data: {
+        message: 'Gemini Live API requested session shutdown',
+        source: 'gemini',
+        timeLeft: '10s',
+      },
+    });
+  });
+
   it('rejects startup if Gemini closes the socket before setup completes', async () => {
     const onEvent = vi.fn<(event: RealtimeEvent) => void>();
     const sessionPromise = provider.createSession(
@@ -374,5 +440,39 @@ describe('GeminiRealtimeProvider', () => {
     expect(onEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'session_end' }),
     );
+  });
+
+  it('resolves close() after a timeout if the socket never emits close', async () => {
+    vi.useFakeTimers();
+
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      readyState: number;
+      send: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ setupComplete: {} });
+
+    const session = await sessionPromise;
+
+    socket.close.mockImplementationOnce(() => {
+      socket.readyState = MockWebSocket.CLOSING;
+    });
+
+    const closePromise = session.close();
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(closePromise).resolves.toBeUndefined();
   });
 });

--- a/backend/tests/providers/gemini-realtime.test.ts
+++ b/backend/tests/providers/gemini-realtime.test.ts
@@ -1,0 +1,378 @@
+const { MockWebSocket, mockSocketInstances } = vi.hoisted(() => {
+  const mockSocketInstances: unknown[] = [];
+
+  class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly url: string;
+    readonly options: Record<string, unknown> | undefined;
+
+    readyState = MockWebSocket.CONNECTING;
+    send = vi.fn((data: string, callback?: (error?: Error) => void) => {
+      callback?.();
+      return true;
+    });
+    close = vi.fn((code?: number, reason?: string) => {
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
+    });
+
+    private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+    constructor(url: string | URL, options?: Record<string, unknown>) {
+      this.url = url.toString();
+      this.options = options;
+      mockSocketInstances.push(this);
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event) ?? [];
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+      return this;
+    }
+
+    once(event: string, listener: (...args: unknown[]) => void): this {
+      const onceListener = (...args: unknown[]) => {
+        this.off(event, onceListener);
+        listener(...args);
+      };
+
+      return this.on(event, onceListener);
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event);
+      if (!listeners) {
+        return this;
+      }
+
+      this.listeners.set(
+        event,
+        listeners.filter((candidate) => candidate !== listener),
+      );
+
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]): boolean {
+      const listeners = this.listeners.get(event);
+      if (!listeners?.length) {
+        return false;
+      }
+
+      for (const listener of [...listeners]) {
+        listener(...args);
+      }
+
+      return true;
+    }
+
+    open(): void {
+      this.readyState = MockWebSocket.OPEN;
+      this.emit('open');
+    }
+
+    emitMessage(message: unknown): void {
+      this.emit('message', Buffer.from(JSON.stringify(message)));
+    }
+  }
+
+  return { MockWebSocket, mockSocketInstances };
+});
+
+vi.mock('ws', () => ({
+  default: MockWebSocket,
+}));
+
+import { GeminiRealtimeProvider } from '../../src/providers/realtime/gemini.js';
+import type { RealtimeEvent } from '../../src/providers/realtime/types.js';
+
+function createJsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('GeminiRealtimeProvider', () => {
+  const mockFetch = vi.fn<typeof fetch>();
+  let provider: GeminiRealtimeProvider;
+
+  beforeEach(() => {
+    mockSocketInstances.length = 0;
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new GeminiRealtimeProvider('test-api-key');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('has the expected id and name', () => {
+    expect(provider.id).toBe('gemini-realtime');
+    expect(provider.name).toBe('Gemini Realtime');
+  });
+
+  it('lists live Gemini models and strips the models/ prefix', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse({
+      models: [
+        {
+          name: 'models/gemini-3.1-flash-live-preview',
+          supportedGenerationMethods: ['bidiGenerateContent'],
+        },
+        {
+          name: 'models/gemini-2.5-flash-live-preview',
+          supportedGenerationMethods: ['generateContent'],
+        },
+        {
+          name: 'models/gemini-2.5-flash',
+          supportedGenerationMethods: ['generateContent'],
+        },
+        {
+          name: 'models/gemini-3.1-flash-live-preview',
+          supportedGenerationMethods: ['bidiGenerateContent'],
+        },
+      ],
+    }));
+
+    await expect(provider.getModels()).resolves.toEqual([
+      'gemini-2.5-flash-live-preview',
+      'gemini-3.1-flash-live-preview',
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://generativelanguage.googleapis.com/v1beta/models?key=test-api-key&pageSize=1000',
+    );
+  });
+
+  it('opens an upstream Gemini socket, sends setup, and streams PCM audio', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be concise',
+        voice: 'Kore',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      url: string;
+      send: ReturnType<typeof vi.fn>;
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    expect(socket.url).toBe(
+      'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=test-api-key',
+    );
+
+    socket.open();
+
+    expect(JSON.parse(socket.send.mock.calls[0]![0] as string)).toEqual({
+      setup: {
+        model: 'models/gemini-3.1-flash-live-preview',
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: {
+                voiceName: 'Kore',
+              },
+            },
+          },
+        },
+        systemInstruction: {
+          parts: [{ text: 'Be concise' }],
+        },
+        inputAudioTranscription: {},
+        outputAudioTranscription: {},
+      },
+    });
+
+    socket.emitMessage({ setupComplete: {} });
+
+    const session = await sessionPromise;
+    await session.sendAudio(Buffer.from('hello-audio'));
+
+    expect(JSON.parse(socket.send.mock.calls[1]![0] as string)).toEqual({
+      realtimeInput: {
+        audio: {
+          data: Buffer.from('hello-audio').toString('base64'),
+          mimeType: 'audio/pcm;rate=16000',
+        },
+      },
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('maps Gemini server messages into RealtimeEvent payloads', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'models/gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be helpful',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      readyState: number;
+      open(): void;
+      emit(event: string, ...args: unknown[]): boolean;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ setupComplete: {} });
+
+    await sessionPromise;
+
+    socket.emitMessage({
+      serverContent: {
+        inputTranscription: {
+          text: 'hello from user',
+        },
+      },
+    });
+    socket.emitMessage({
+      serverContent: {
+        modelTurn: {
+          parts: [
+            {
+              inlineData: {
+                mimeType: 'audio/pcm;rate=24000',
+                data: 'YmFzZTY0LWF1ZGlv',
+              },
+            },
+          ],
+        },
+      },
+    });
+    socket.emitMessage({
+      serverContent: {
+        outputTranscription: {
+          text: 'assistant reply',
+        },
+      },
+    });
+    socket.emit('error', new Error('Gemini websocket error'));
+    socket.readyState = MockWebSocket.CLOSED;
+    socket.emit('close', 1011, Buffer.from('upstream closed'));
+
+    expect(onEvent.mock.calls).toEqual([
+      [
+        {
+          type: 'transcript',
+          data: {
+            role: 'user',
+            text: 'hello from user',
+            final: true,
+          },
+        },
+      ],
+      [
+        {
+          type: 'audio',
+          data: {
+            chunk: 'YmFzZTY0LWF1ZGlv',
+            mimeType: 'audio/pcm;rate=24000',
+          },
+        },
+      ],
+      [
+        {
+          type: 'transcript',
+          data: {
+            role: 'assistant',
+            text: 'assistant reply',
+            final: true,
+          },
+        },
+      ],
+      [
+        {
+          type: 'error',
+          data: {
+            message: 'Gemini websocket error',
+            source: 'gemini',
+          },
+        },
+      ],
+      [
+        {
+          type: 'session_end',
+          data: {
+            code: 1011,
+            reason: 'upstream closed',
+          },
+        },
+      ],
+    ]);
+  });
+
+  it('rejects startup if Gemini closes the socket before setup completes', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      open(): void;
+      emit(event: string, ...args: unknown[]): boolean;
+    };
+
+    socket.open();
+    socket.emit('close', 1008, Buffer.from('invalid setup'));
+
+    await expect(sessionPromise).rejects.toThrow('invalid setup');
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
+  });
+
+  it('does not emit session_end when the session is closed intentionally', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gemini-3.1-flash-live-preview',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      send: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ setupComplete: {} });
+
+    const session = await sessionPromise;
+    await session.close();
+
+    expect(JSON.parse(socket.send.mock.calls[1]![0] as string)).toEqual({
+      realtimeInput: {
+        audioStreamEnd: true,
+      },
+    });
+    expect(socket.close).toHaveBeenCalledWith(1000, 'Session closed');
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
+  });
+});

--- a/backend/tests/providers/realtime-registry.test.ts
+++ b/backend/tests/providers/realtime-registry.test.ts
@@ -3,6 +3,7 @@ import {
   getSupportedRealtimeProviders,
   registerRealtimeProvider,
 } from '../../src/providers/realtime/registry.js';
+import { GeminiRealtimeProvider } from '../../src/providers/realtime/gemini.js';
 import type {
   IRealtimeProvider,
   IRealtimeSession,
@@ -53,5 +54,12 @@ describe('Realtime Provider Registry', () => {
     const providers = getSupportedRealtimeProviders();
 
     expect(providers).toContain(providerId);
+  });
+
+  it('creates the built-in Gemini realtime provider', () => {
+    const provider = createRealtimeProvider('gemini-realtime', 'test-key');
+
+    expect(provider).toBeInstanceOf(GeminiRealtimeProvider);
+    expect(provider.id).toBe('gemini-realtime');
   });
 });


### PR DESCRIPTION
## Summary
- add `GeminiRealtimeProvider` for Gemini Live API over raw WebSocket
- register `gemini-realtime` in the realtime provider registry
- add unit coverage for model listing, session setup, audio streaming, event mapping, shutdown behavior, and built-in registry wiring

## Testing
- `npm run test --workspace=backend`
- `npm run build --workspace=backend`

Closes #31