### PR TITLE
feat: add ElevenLabs realtime provider

### DIFF
--- a/backend/src/providers/realtime/elevenlabs.ts
+++ b/backend/src/providers/realtime/elevenlabs.ts
@@ -1,0 +1,519 @@
+import { WebSocket } from 'ws';
+import type {
+  IRealtimeProvider,
+  IRealtimeSession,
+  RealtimeEvent,
+  RealtimeSessionConfig,
+} from './types.js';
+
+const API_BASE_URL = 'https://api.elevenlabs.io';
+const LIST_AGENTS_URL = `${API_BASE_URL}/v1/convai/agents`;
+const SIGNED_URL_PATH = '/v1/convai/conversation/get-signed-url';
+const PAGE_SIZE = 100;
+const SESSION_INIT_TIMEOUT_MS = 15_000;
+
+interface ElevenLabsAgentSummary {
+  agent_id?: string;
+}
+
+interface ElevenLabsListAgentsResponse {
+  agents?: ElevenLabsAgentSummary[];
+  has_more?: boolean;
+  next_cursor?: string | null;
+}
+
+interface ElevenLabsSignedUrlResponse {
+  signed_url?: string;
+}
+
+interface ElevenLabsConversationInitiationMetadataEvent {
+  conversation_id?: string;
+  agent_output_audio_format?: string;
+  user_input_audio_format?: string;
+}
+
+interface ElevenLabsPingEvent {
+  event_id?: number;
+  ping_ms?: number;
+}
+
+interface ElevenLabsAudioEvent {
+  audio_base_64?: string;
+  event_id?: number;
+  alignment?: unknown;
+}
+
+interface ElevenLabsUserTranscriptEvent {
+  user_transcript?: string;
+}
+
+interface ElevenLabsAgentResponseEvent {
+  agent_response?: string;
+}
+
+interface ElevenLabsAgentResponseCorrectionEvent {
+  original_agent_response?: string;
+  corrected_agent_response?: string;
+}
+
+interface ElevenLabsServerMessage {
+  type?: string;
+  conversation_initiation_metadata_event?: ElevenLabsConversationInitiationMetadataEvent;
+  ping_event?: ElevenLabsPingEvent;
+  audio_event?: ElevenLabsAudioEvent;
+  user_transcription_event?: ElevenLabsUserTranscriptEvent;
+  agent_response_event?: ElevenLabsAgentResponseEvent;
+  agent_response_correction_event?: ElevenLabsAgentResponseCorrectionEvent;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function bufferToString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value).toString('utf8');
+  }
+
+  if (Array.isArray(value)) {
+    return Buffer.concat(
+      value.map((chunk) => (typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk))),
+    ).toString('utf8');
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return value.toString('utf8');
+  }
+
+  return '';
+}
+
+async function readJson<T>(response: Response, invalidMessage: string): Promise<T> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new Error(invalidMessage);
+  }
+}
+
+async function throwApiError(response: Response): Promise<never> {
+  const body = await response.text();
+  const suffix = body ? ` ${body}` : '';
+  throw new Error(`ElevenLabs API error: ${response.status}${suffix}`);
+}
+
+async function sendJson(socket: WebSocket, message: Record<string, unknown>): Promise<void> {
+  if (socket.readyState !== WebSocket.OPEN) {
+    throw new Error('ElevenLabs realtime socket is not open');
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    socket.send(JSON.stringify(message), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function parseServerMessage(raw: unknown): ElevenLabsServerMessage | null {
+  const payload = bufferToString(raw);
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(payload) as ElevenLabsServerMessage;
+  } catch {
+    return null;
+  }
+}
+
+function buildConversationInitiationMessage(
+  config: RealtimeSessionConfig,
+): Record<string, unknown> {
+  const conversationConfigOverride: Record<string, unknown> = {};
+  const systemPrompt = config.systemPrompt.trim();
+  const voiceId = config.voice?.trim();
+
+  if (systemPrompt) {
+    conversationConfigOverride.agent = {
+      prompt: {
+        prompt: systemPrompt,
+      },
+    };
+  }
+
+  if (voiceId) {
+    conversationConfigOverride.tts = {
+      voice_id: voiceId,
+    };
+  }
+
+  if (Object.keys(conversationConfigOverride).length === 0) {
+    return { type: 'conversation_initiation_client_data' };
+  }
+
+  return {
+    type: 'conversation_initiation_client_data',
+    conversation_config_override: conversationConfigOverride,
+  };
+}
+
+class ElevenLabsRealtimeSession implements IRealtimeSession {
+  private closePromise: Promise<void> | null = null;
+
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly dispose: () => void,
+  ) {}
+
+  async sendAudio(chunk: Buffer): Promise<void> {
+    await sendJson(this.socket, {
+      user_audio_chunk: chunk.toString('base64'),
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.dispose();
+
+    if (this.socket.readyState === WebSocket.CLOSED) {
+      return;
+    }
+
+    this.closePromise = new Promise<void>((resolve) => {
+      const finish = () => {
+        this.socket.off('close', finish);
+        resolve();
+      };
+
+      this.socket.on('close', finish);
+
+      if (this.socket.readyState === WebSocket.OPEN) {
+        this.socket.close(1000, 'Sound Lab session closed');
+        return;
+      }
+
+      if (this.socket.readyState === WebSocket.CONNECTING) {
+        this.socket.close();
+        return;
+      }
+
+      finish();
+    });
+
+    await this.closePromise;
+  }
+}
+
+export class ElevenLabsRealtimeProvider implements IRealtimeProvider {
+  readonly id = 'elevenlabs-realtime';
+  readonly name = 'ElevenLabs Realtime';
+
+  constructor(private readonly apiKey: string) {}
+
+  async getModels(): Promise<string[]> {
+    const agentIds: string[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const url = new URL(LIST_AGENTS_URL);
+      url.searchParams.set('page_size', String(PAGE_SIZE));
+      url.searchParams.set('archived', 'false');
+
+      if (cursor) {
+        url.searchParams.set('cursor', cursor);
+      }
+
+      const response = await fetch(url, {
+        headers: {
+          'xi-api-key': this.apiKey,
+        },
+      });
+
+      if (!response.ok) {
+        await throwApiError(response);
+      }
+
+      const data = await readJson<ElevenLabsListAgentsResponse>(
+        response,
+        'ElevenLabs API returned an invalid agents response',
+      );
+
+      if (!Array.isArray(data.agents)) {
+        throw new Error('ElevenLabs API returned an invalid agents response');
+      }
+
+      for (const agent of data.agents) {
+        if (typeof agent.agent_id === 'string' && agent.agent_id) {
+          agentIds.push(agent.agent_id);
+        }
+      }
+
+      cursor = data.has_more ? data.next_cursor ?? null : null;
+    } while (cursor);
+
+    return [...new Set(agentIds)];
+  }
+
+  async createSession(
+    config: RealtimeSessionConfig,
+    onEvent: (event: RealtimeEvent) => void,
+  ): Promise<IRealtimeSession> {
+    const agentId = config.model.trim();
+
+    if (!agentId) {
+      throw new Error('ElevenLabs realtime sessions require an agent ID');
+    }
+
+    const signedUrl = await this.getSignedUrl(agentId);
+    return this.openSession(signedUrl, config, onEvent);
+  }
+
+  private async getSignedUrl(agentId: string): Promise<string> {
+    const url = new URL(SIGNED_URL_PATH, API_BASE_URL);
+    url.searchParams.set('agent_id', agentId);
+
+    const response = await fetch(url, {
+      headers: {
+        'xi-api-key': this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      await throwApiError(response);
+    }
+
+    const data = await readJson<ElevenLabsSignedUrlResponse>(
+      response,
+      'ElevenLabs API returned an invalid signed URL response',
+    );
+
+    if (!data.signed_url) {
+      throw new Error('ElevenLabs API returned an invalid signed URL response');
+    }
+
+    return data.signed_url;
+  }
+
+  private async openSession(
+    signedUrl: string,
+    config: RealtimeSessionConfig,
+    onEvent: (event: RealtimeEvent) => void,
+  ): Promise<IRealtimeSession> {
+    const socket = new WebSocket(signedUrl);
+    const pingTimers = new Set<NodeJS.Timeout>();
+
+    const dispose = () => {
+      for (const timer of pingTimers) {
+        clearTimeout(timer);
+      }
+
+      pingTimers.clear();
+    };
+
+    return new Promise<IRealtimeSession>((resolve, reject) => {
+      let ready = false;
+      let initCompleted = false;
+
+      const initTimeout = setTimeout(() => {
+        if (ready) {
+          return;
+        }
+
+        dispose();
+        reject(new Error('Timed out waiting for ElevenLabs realtime session to initialize'));
+        socket.close();
+      }, SESSION_INIT_TIMEOUT_MS);
+
+      const completeInit = () => {
+        if (initCompleted) {
+          return;
+        }
+
+        initCompleted = true;
+        clearTimeout(initTimeout);
+      };
+
+      socket.on('open', async () => {
+        try {
+          await sendJson(socket, buildConversationInitiationMessage(config));
+        } catch (error) {
+          completeInit();
+          dispose();
+          reject(new Error(getErrorMessage(error, 'Failed to initialize ElevenLabs session')));
+          socket.close();
+        }
+      });
+
+      socket.on('message', (rawMessage) => {
+        const message = parseServerMessage(rawMessage);
+        if (!message?.type) {
+          onEvent({
+            type: 'error',
+            data: { message: 'Invalid ElevenLabs realtime message payload' },
+          });
+          return;
+        }
+
+        switch (message.type) {
+          case 'conversation_initiation_metadata': {
+            if (!ready) {
+              ready = true;
+              completeInit();
+              resolve(new ElevenLabsRealtimeSession(socket, dispose));
+            }
+
+            return;
+          }
+
+          case 'ping': {
+            const eventId = message.ping_event?.event_id;
+            if (typeof eventId !== 'number') {
+              onEvent({
+                type: 'error',
+                data: { message: 'Invalid ElevenLabs ping event payload' },
+              });
+              return;
+            }
+
+            const sendPong = () => {
+              void sendJson(socket, {
+                type: 'pong',
+                event_id: eventId,
+              }).catch((error) => {
+                onEvent({
+                  type: 'error',
+                  data: {
+                    message: getErrorMessage(error, 'Failed to respond to ElevenLabs ping'),
+                  },
+                });
+              });
+            };
+
+            const delayMs = message.ping_event?.ping_ms;
+            if (typeof delayMs === 'number' && Number.isFinite(delayMs) && delayMs > 0) {
+              const timer = setTimeout(() => {
+                pingTimers.delete(timer);
+                sendPong();
+              }, Math.min(delayMs, 1_000));
+
+              pingTimers.add(timer);
+              return;
+            }
+
+            sendPong();
+            return;
+          }
+
+          case 'user_transcript': {
+            const text = message.user_transcription_event?.user_transcript;
+            if (typeof text === 'string' && text) {
+              onEvent({
+                type: 'transcript',
+                data: { role: 'user', text },
+              });
+            }
+            return;
+          }
+
+          case 'agent_response': {
+            const text = message.agent_response_event?.agent_response;
+            if (typeof text === 'string' && text) {
+              onEvent({
+                type: 'transcript',
+                data: { role: 'assistant', text },
+              });
+            }
+            return;
+          }
+
+          case 'agent_response_correction': {
+            const correction = message.agent_response_correction_event?.corrected_agent_response;
+            const original = message.agent_response_correction_event?.original_agent_response;
+
+            if (typeof correction === 'string' && correction) {
+              onEvent({
+                type: 'transcript',
+                data: {
+                  role: 'assistant',
+                  text: correction,
+                  corrected: true,
+                  originalText: original,
+                },
+              });
+            }
+            return;
+          }
+
+          case 'audio': {
+            const audioBase64 = message.audio_event?.audio_base_64;
+            if (typeof audioBase64 === 'string' && audioBase64) {
+              onEvent({
+                type: 'audio',
+                data: {
+                  audioBase64,
+                  eventId: message.audio_event?.event_id,
+                  alignment: message.audio_event?.alignment,
+                },
+              });
+            }
+            return;
+          }
+
+          default:
+            return;
+        }
+      });
+
+      socket.on('error', (error) => {
+        const message = getErrorMessage(error, 'ElevenLabs realtime socket error');
+
+        if (!ready) {
+          completeInit();
+          dispose();
+          reject(new Error(message));
+          return;
+        }
+
+        onEvent({
+          type: 'error',
+          data: { message },
+        });
+      });
+
+      socket.on('close', (code, reason) => {
+        const reasonText = bufferToString(reason);
+        completeInit();
+        dispose();
+
+        if (!ready) {
+          reject(
+            new Error(
+              reasonText
+                ? `ElevenLabs realtime session closed before initialization (${code}: ${reasonText})`
+                : `ElevenLabs realtime session closed before initialization (${code})`,
+            ),
+          );
+          return;
+        }
+
+        onEvent({
+          type: 'session_end',
+          data: { code, reason: reasonText || undefined },
+        });
+      });
+    });
+  }
+}

--- a/backend/src/providers/realtime/elevenlabs.ts
+++ b/backend/src/providers/realtime/elevenlabs.ts
@@ -11,6 +11,7 @@ const LIST_AGENTS_URL = `${API_BASE_URL}/v1/convai/agents`;
 const SIGNED_URL_PATH = '/v1/convai/conversation/get-signed-url';
 const PAGE_SIZE = 100;
 const SESSION_INIT_TIMEOUT_MS = 15_000;
+const SESSION_CLOSE_TIMEOUT_MS = 5_000;
 
 interface ElevenLabsAgentSummary {
   agent_id?: string;
@@ -123,6 +124,45 @@ async function sendJson(socket: WebSocket, message: Record<string, unknown>): Pr
   });
 }
 
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  if (socket.readyState >= WebSocket.CLOSING) {
+    return;
+  }
+
+  socket.close(code, reason);
+}
+
+function waitForSocketClose(socket: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (): void => {
+      if (resolved) {
+        return;
+      }
+
+      resolved = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      resolve();
+    };
+
+    socket.once('close', () => {
+      finish();
+    });
+
+    timeoutHandle = setTimeout(() => {
+      if ('terminate' in socket && typeof socket.terminate === 'function') {
+        socket.terminate();
+      }
+
+      finish();
+    }, SESSION_CLOSE_TIMEOUT_MS);
+  });
+}
+
 function parseServerMessage(raw: unknown): ElevenLabsServerMessage | null {
   const payload = bufferToString(raw);
   if (!payload) {
@@ -169,13 +209,19 @@ function buildConversationInitiationMessage(
 
 class ElevenLabsRealtimeSession implements IRealtimeSession {
   private closePromise: Promise<void> | null = null;
+  private closed = false;
 
   constructor(
     private readonly socket: WebSocket,
     private readonly dispose: () => void,
+    private readonly suppressRemoteSessionEnd: () => void,
   ) {}
 
   async sendAudio(chunk: Buffer): Promise<void> {
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('ElevenLabs Realtime session is not open');
+    }
+
     await sendJson(this.socket, {
       user_audio_chunk: chunk.toString('base64'),
     });
@@ -186,32 +232,17 @@ class ElevenLabsRealtimeSession implements IRealtimeSession {
       return this.closePromise;
     }
 
+    this.closed = true;
+    this.suppressRemoteSessionEnd();
     this.dispose();
 
     if (this.socket.readyState === WebSocket.CLOSED) {
-      return;
+      this.closePromise = Promise.resolve();
+      return this.closePromise;
     }
 
-    this.closePromise = new Promise<void>((resolve) => {
-      const finish = () => {
-        this.socket.off('close', finish);
-        resolve();
-      };
-
-      this.socket.on('close', finish);
-
-      if (this.socket.readyState === WebSocket.OPEN) {
-        this.socket.close(1000, 'Sound Lab session closed');
-        return;
-      }
-
-      if (this.socket.readyState === WebSocket.CONNECTING) {
-        this.socket.close();
-        return;
-      }
-
-      finish();
-    });
+    this.closePromise = waitForSocketClose(this.socket);
+    closeSocket(this.socket, 1000, 'Sound Lab session closed');
 
     await this.closePromise;
   }
@@ -314,6 +345,7 @@ export class ElevenLabsRealtimeProvider implements IRealtimeProvider {
   ): Promise<IRealtimeSession> {
     const socket = new WebSocket(signedUrl);
     const pingTimers = new Set<NodeJS.Timeout>();
+    let suppressRemoteSessionEnd = false;
 
     const dispose = () => {
       for (const timer of pingTimers) {
@@ -321,6 +353,10 @@ export class ElevenLabsRealtimeProvider implements IRealtimeProvider {
       }
 
       pingTimers.clear();
+    };
+
+    const suppressSessionEnd = () => {
+      suppressRemoteSessionEnd = true;
     };
 
     return new Promise<IRealtimeSession>((resolve, reject) => {
@@ -372,7 +408,7 @@ export class ElevenLabsRealtimeProvider implements IRealtimeProvider {
             if (!ready) {
               ready = true;
               completeInit();
-              resolve(new ElevenLabsRealtimeSession(socket, dispose));
+              resolve(new ElevenLabsRealtimeSession(socket, dispose, suppressSessionEnd));
             }
 
             return;
@@ -509,10 +545,12 @@ export class ElevenLabsRealtimeProvider implements IRealtimeProvider {
           return;
         }
 
-        onEvent({
-          type: 'session_end',
-          data: { code, reason: reasonText || undefined },
-        });
+        if (!suppressRemoteSessionEnd) {
+          onEvent({
+            type: 'session_end',
+            data: { code, reason: reasonText || undefined },
+          });
+        }
       });
     });
   }

--- a/backend/src/providers/realtime/registry.ts
+++ b/backend/src/providers/realtime/registry.ts
@@ -1,8 +1,11 @@
 import type { IRealtimeProvider } from './types.js';
+import { ElevenLabsRealtimeProvider } from './elevenlabs.js';
 
 export type RealtimeProviderConstructor = new (apiKey: string) => IRealtimeProvider;
 
-const PROVIDERS: Record<string, RealtimeProviderConstructor> = {};
+const PROVIDERS: Record<string, RealtimeProviderConstructor> = {
+  'elevenlabs-realtime': ElevenLabsRealtimeProvider,
+};
 
 export function createRealtimeProvider(providerId: string, apiKey: string): IRealtimeProvider {
   const Provider = PROVIDERS[providerId];

--- a/backend/src/providers/realtime/registry.ts
+++ b/backend/src/providers/realtime/registry.ts
@@ -3,9 +3,7 @@ import { ElevenLabsRealtimeProvider } from './elevenlabs.js';
 
 export type RealtimeProviderConstructor = new (apiKey: string) => IRealtimeProvider;
 
-const PROVIDERS: Record<string, RealtimeProviderConstructor> = {
-  'elevenlabs-realtime': ElevenLabsRealtimeProvider,
-};
+const PROVIDERS: Record<string, RealtimeProviderConstructor> = {};
 
 export function createRealtimeProvider(providerId: string, apiKey: string): IRealtimeProvider {
   const Provider = PROVIDERS[providerId];
@@ -27,3 +25,5 @@ export function registerRealtimeProvider(
 export function getSupportedRealtimeProviders(): string[] {
   return Object.keys(PROVIDERS);
 }
+
+registerRealtimeProvider('elevenlabs-realtime', ElevenLabsRealtimeProvider);

--- a/backend/tests/providers/elevenlabs-realtime.test.ts
+++ b/backend/tests/providers/elevenlabs-realtime.test.ts
@@ -8,6 +8,8 @@ const { MockWebSocket, mockSockets } = vi.hoisted(() => {
     readonly sentMessages: string[] = [];
     readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
     readyState = MockWebSocket.CONNECTING;
+    autoEmitCloseOnClose = true;
+    terminated = false;
     closeCode?: number;
     closeReason?: string;
 
@@ -31,6 +33,15 @@ const { MockWebSocket, mockSockets } = vi.hoisted(() => {
       return this;
     }
 
+    once(event: string, listener: (...args: unknown[]) => void): this {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        listener(...args);
+      };
+
+      return this.on(event, wrapped);
+    }
+
     send(data: string, callback?: (error?: Error) => void): void {
       this.sentMessages.push(data);
       callback?.();
@@ -39,8 +50,21 @@ const { MockWebSocket, mockSockets } = vi.hoisted(() => {
     close(code = 1000, reason = ''): void {
       this.closeCode = code;
       this.closeReason = reason;
-      this.readyState = MockWebSocket.CLOSED;
+      this.readyState = this.autoEmitCloseOnClose
+        ? MockWebSocket.CLOSED
+        : MockWebSocket.CLOSING;
+
+      if (!this.autoEmitCloseOnClose) {
+        return;
+      }
+
       this.emit('close', code, Buffer.from(reason));
+    }
+
+    terminate(): void {
+      this.terminated = true;
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close', this.closeCode ?? 1006, Buffer.from(this.closeReason ?? 'terminated'));
     }
 
     open(): void {
@@ -336,6 +360,56 @@ describe('ElevenLabsRealtimeProvider', () => {
     });
 
     await session.close();
+  });
+
+  it('terminates the socket if ElevenLabs never responds to the close handshake', async () => {
+    vi.useFakeTimers();
+
+    try {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?agent_id=agent-stuck&token=abc',
+        }), { status: 200 }),
+      );
+
+      const events: RealtimeEvent[] = [];
+      const sessionPromise = provider.createSession(
+        {
+          model: 'agent-stuck',
+          systemPrompt: 'prompt',
+        },
+        (event) => {
+          events.push(event);
+        },
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSockets).toHaveLength(1);
+      });
+
+      const socket = mockSockets[0];
+      socket.open();
+      socket.receive({
+        type: 'conversation_initiation_metadata',
+        conversation_initiation_metadata_event: {
+          conversation_id: 'conv-stuck',
+        },
+      });
+
+      const session = await sessionPromise;
+      socket.autoEmitCloseOnClose = false;
+
+      const closePromise = session.close();
+
+      expect(socket.readyState).toBe(MockWebSocket.CLOSING);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await closePromise;
+
+      expect(socket.terminated).toBe(true);
+      expect(events).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rejects when the websocket closes before session initialization completes', async () => {

--- a/backend/tests/providers/elevenlabs-realtime.test.ts
+++ b/backend/tests/providers/elevenlabs-realtime.test.ts
@@ -1,0 +1,368 @@
+const { MockWebSocket, mockSockets } = vi.hoisted(() => {
+  class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly sentMessages: string[] = [];
+    readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+    readyState = MockWebSocket.CONNECTING;
+    closeCode?: number;
+    closeReason?: string;
+
+    constructor(public readonly url: string) {
+      mockSockets.push(this);
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const handlers = this.listeners.get(event) ?? [];
+      handlers.push(listener);
+      this.listeners.set(event, handlers);
+      return this;
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void): this {
+      const handlers = this.listeners.get(event) ?? [];
+      this.listeners.set(
+        event,
+        handlers.filter((candidate) => candidate !== listener),
+      );
+      return this;
+    }
+
+    send(data: string, callback?: (error?: Error) => void): void {
+      this.sentMessages.push(data);
+      callback?.();
+    }
+
+    close(code = 1000, reason = ''): void {
+      this.closeCode = code;
+      this.closeReason = reason;
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close', code, Buffer.from(reason));
+    }
+
+    open(): void {
+      this.readyState = MockWebSocket.OPEN;
+      this.emit('open');
+    }
+
+    fail(error: Error): void {
+      this.emit('error', error);
+    }
+
+    receive(payload: object): void {
+      this.emit('message', Buffer.from(JSON.stringify(payload)));
+    }
+
+    private emit(event: string, ...args: unknown[]): void {
+      const handlers = this.listeners.get(event) ?? [];
+      for (const handler of handlers) {
+        handler(...args);
+      }
+    }
+  }
+
+  const mockSockets: MockWebSocket[] = [];
+
+  return { MockWebSocket, mockSockets };
+});
+
+vi.mock('ws', () => ({
+  WebSocket: MockWebSocket,
+}));
+
+import { ElevenLabsRealtimeProvider } from '../../src/providers/realtime/elevenlabs.js';
+import type { RealtimeEvent } from '../../src/providers/realtime/types.js';
+
+describe('ElevenLabsRealtimeProvider', () => {
+  let provider: ElevenLabsRealtimeProvider;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new ElevenLabsRealtimeProvider('test-api-key');
+    mockSockets.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns agent IDs from the ElevenLabs agents API across pages', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          agents: [{ agent_id: 'agent-1' }],
+          has_more: true,
+          next_cursor: 'cursor-2',
+        }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          agents: [{ agent_id: 'agent-2' }, { agent_id: 'agent-1' }],
+          has_more: false,
+          next_cursor: null,
+        }), { status: 200 }),
+      );
+
+    const models = await provider.getModels();
+
+    expect(models).toEqual(['agent-1', 'agent-2']);
+
+    const firstUrl = new URL(String(mockFetch.mock.calls[0][0]));
+    expect(firstUrl.pathname).toBe('/v1/convai/agents');
+    expect(firstUrl.searchParams.get('page_size')).toBe('100');
+    expect(firstUrl.searchParams.get('archived')).toBe('false');
+
+    const secondUrl = new URL(String(mockFetch.mock.calls[1][0]));
+    expect(secondUrl.searchParams.get('cursor')).toBe('cursor-2');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      { headers: { 'xi-api-key': 'test-api-key' } },
+    );
+  });
+
+  it('creates a session via signed URL and sends conversation overrides on open', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?agent_id=agent-123&token=abc',
+      }), { status: 200 }),
+    );
+
+    const events: RealtimeEvent[] = [];
+    const sessionPromise = provider.createSession(
+      {
+        model: 'agent-123',
+        systemPrompt: 'Be concise.',
+        voice: 'voice-456',
+      },
+      (event) => {
+        events.push(event);
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(mockSockets).toHaveLength(1);
+    });
+
+    const socket = mockSockets[0];
+    expect(socket.url).toContain('token=abc');
+
+    socket.open();
+    await vi.waitFor(() => {
+      expect(socket.sentMessages).toHaveLength(1);
+    });
+
+    expect(JSON.parse(socket.sentMessages[0])).toEqual({
+      type: 'conversation_initiation_client_data',
+      conversation_config_override: {
+        agent: {
+          prompt: {
+            prompt: 'Be concise.',
+          },
+        },
+        tts: {
+          voice_id: 'voice-456',
+        },
+      },
+    });
+
+    socket.receive({
+      type: 'conversation_initiation_metadata',
+      conversation_initiation_metadata_event: {
+        conversation_id: 'conv-123',
+        agent_output_audio_format: 'pcm_16000',
+        user_input_audio_format: 'pcm_16000',
+      },
+    });
+
+    const session = await sessionPromise;
+    await session.sendAudio(Buffer.from('hello'));
+
+    expect(JSON.parse(socket.sentMessages[1])).toEqual({
+      user_audio_chunk: Buffer.from('hello').toString('base64'),
+    });
+    expect(events).toEqual([]);
+  });
+
+  it('maps ElevenLabs websocket events into generic realtime events and responds to ping', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?agent_id=agent-789&token=abc',
+      }), { status: 200 }),
+    );
+
+    const events: RealtimeEvent[] = [];
+    const sessionPromise = provider.createSession(
+      {
+        model: 'agent-789',
+        systemPrompt: '',
+      },
+      (event) => {
+        events.push(event);
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(mockSockets).toHaveLength(1);
+    });
+
+    const socket = mockSockets[0];
+    socket.open();
+    socket.receive({
+      type: 'conversation_initiation_metadata',
+      conversation_initiation_metadata_event: {
+        conversation_id: 'conv-789',
+      },
+    });
+
+    await sessionPromise;
+
+    socket.receive({
+      type: 'user_transcript',
+      user_transcription_event: {
+        user_transcript: 'Hello there',
+      },
+    });
+    socket.receive({
+      type: 'agent_response',
+      agent_response_event: {
+        agent_response: 'Hi. How can I help?',
+      },
+    });
+    socket.receive({
+      type: 'agent_response_correction',
+      agent_response_correction_event: {
+        original_agent_response: 'Hi. How can I help you today?',
+        corrected_agent_response: 'Hi. How can I help?',
+      },
+    });
+    socket.receive({
+      type: 'audio',
+      audio_event: {
+        audio_base_64: 'c29tZS1hdWRpbw==',
+        event_id: 42,
+        alignment: { chars: ['H'] },
+      },
+    });
+    socket.receive({
+      type: 'ping',
+      ping_event: {
+        event_id: 99,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.sentMessages).toHaveLength(2);
+    });
+
+    expect(events).toEqual([
+      {
+        type: 'transcript',
+        data: { role: 'user', text: 'Hello there' },
+      },
+      {
+        type: 'transcript',
+        data: { role: 'assistant', text: 'Hi. How can I help?' },
+      },
+      {
+        type: 'transcript',
+        data: {
+          role: 'assistant',
+          text: 'Hi. How can I help?',
+          corrected: true,
+          originalText: 'Hi. How can I help you today?',
+        },
+      },
+      {
+        type: 'audio',
+        data: {
+          audioBase64: 'c29tZS1hdWRpbw==',
+          eventId: 42,
+          alignment: { chars: ['H'] },
+        },
+      },
+    ]);
+    expect(JSON.parse(socket.sentMessages[1])).toEqual({
+      type: 'pong',
+      event_id: 99,
+    });
+  });
+
+  it('emits session_end when the upstream websocket closes after initialization', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?agent_id=agent-close&token=abc',
+      }), { status: 200 }),
+    );
+
+    const events: RealtimeEvent[] = [];
+    const sessionPromise = provider.createSession(
+      {
+        model: 'agent-close',
+        systemPrompt: 'prompt',
+      },
+      (event) => {
+        events.push(event);
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(mockSockets).toHaveLength(1);
+    });
+
+    const socket = mockSockets[0];
+    socket.open();
+    socket.receive({
+      type: 'conversation_initiation_metadata',
+      conversation_initiation_metadata_event: {
+        conversation_id: 'conv-close',
+      },
+    });
+
+    const session = await sessionPromise;
+    socket.close(1011, 'upstream failure');
+
+    await vi.waitFor(() => {
+      expect(events).toEqual([
+        {
+          type: 'session_end',
+          data: { code: 1011, reason: 'upstream failure' },
+        },
+      ]);
+    });
+
+    await session.close();
+  });
+
+  it('rejects when the websocket closes before session initialization completes', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?agent_id=agent-fail&token=abc',
+      }), { status: 200 }),
+    );
+
+    const sessionPromise = provider.createSession(
+      {
+        model: 'agent-fail',
+        systemPrompt: 'prompt',
+      },
+      vi.fn(),
+    );
+
+    await vi.waitFor(() => {
+      expect(mockSockets).toHaveLength(1);
+    });
+
+    const socket = mockSockets[0];
+    socket.open();
+    socket.close(4001, 'invalid overrides');
+
+    await expect(sessionPromise).rejects.toThrow(
+      'ElevenLabs realtime session closed before initialization (4001: invalid overrides)',
+    );
+  });
+});

--- a/backend/tests/providers/realtime-registry.test.ts
+++ b/backend/tests/providers/realtime-registry.test.ts
@@ -3,6 +3,7 @@ import {
   getSupportedRealtimeProviders,
   registerRealtimeProvider,
 } from '../../src/providers/realtime/registry.js';
+import { ElevenLabsRealtimeProvider } from '../../src/providers/realtime/elevenlabs.js';
 import type {
   IRealtimeProvider,
   IRealtimeSession,
@@ -34,6 +35,13 @@ class TestRealtimeProvider implements IRealtimeProvider {
 describe('Realtime Provider Registry', () => {
   const providerId = `test-realtime-${Math.random().toString(36).slice(2)}`;
 
+  it('returns the built-in ElevenLabs realtime provider', () => {
+    const provider = createRealtimeProvider('elevenlabs-realtime', 'test-key');
+
+    expect(provider).toBeInstanceOf(ElevenLabsRealtimeProvider);
+    expect(provider.id).toBe('elevenlabs-realtime');
+  });
+
   it('returns a registered realtime provider', () => {
     registerRealtimeProvider(providerId, TestRealtimeProvider);
 
@@ -52,6 +60,7 @@ describe('Realtime Provider Registry', () => {
   it('includes registered providers in the supported list', () => {
     const providers = getSupportedRealtimeProviders();
 
+    expect(providers).toContain('elevenlabs-realtime');
     expect(providers).toContain(providerId);
   });
 });


### PR DESCRIPTION
## Summary
- add `ElevenLabsRealtimeProvider` for ConvAI agents using the official signed-URL websocket flow
- map ElevenLabs realtime websocket events into the existing generic `RealtimeEvent` contract and handle ping/pong + session shutdown
- register `elevenlabs-realtime` in the realtime registry and add provider/registry coverage

## Verification
- `npm run build --workspace=backend`
- `npm run test --workspace=backend`

## Notes
- `RealtimeSessionConfig.model` is interpreted as ElevenLabs `agent_id` for this provider
- live manual verification against ElevenLabs was not run locally because no real `xi-api-key` / `agent_id` was available in the environment

Closes #32