### PR TITLE
feat: add Inworld realtime provider

### DIFF
--- a/backend/src/providers/realtime/inworld.ts
+++ b/backend/src/providers/realtime/inworld.ts
@@ -13,6 +13,7 @@ const INWORLD_REALTIME_URL = 'wss://api.inworld.ai/api/v1/realtime/session';
 const DEFAULT_REALTIME_MODEL = 'google-ai-studio/gemini-2.5-flash';
 const DEFAULT_VOICE = 'Dennis';
 const DEFAULT_TTS_MODEL = 'inworld-tts-1.5-mini';
+const STARTUP_TIMEOUT_MS = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -304,6 +305,13 @@ export class InworldRealtimeProvider implements IRealtimeProvider {
     };
 
     return new Promise<IRealtimeSession>((resolve, reject) => {
+      const startupTimer = setTimeout(() => {
+        failStartup(
+          `Inworld Realtime session startup timed out after ${STARTUP_TIMEOUT_MS}ms`,
+        );
+      }, STARTUP_TIMEOUT_MS);
+      startupTimer.unref?.();
+
       const settleStartup = (
         kind: 'resolve' | 'reject',
         payload: IRealtimeSession | Error,
@@ -313,6 +321,7 @@ export class InworldRealtimeProvider implements IRealtimeProvider {
         }
 
         startupSettled = true;
+        clearTimeout(startupTimer);
 
         if (kind === 'resolve') {
           resolve(payload as IRealtimeSession);

--- a/backend/src/providers/realtime/inworld.ts
+++ b/backend/src/providers/realtime/inworld.ts
@@ -1,0 +1,453 @@
+import { randomUUID } from 'node:crypto';
+import WebSocket, { type RawData } from 'ws';
+import type {
+  IRealtimeProvider,
+  IRealtimeSession,
+  RealtimeEvent,
+  RealtimeSessionConfig,
+} from './types.js';
+
+const INWORLD_BASE_URL = 'https://api.inworld.ai';
+const INWORLD_MODELS_URL = `${INWORLD_BASE_URL}/v1/models`;
+const INWORLD_REALTIME_URL = 'wss://api.inworld.ai/api/v1/realtime/session';
+const DEFAULT_REALTIME_MODEL = 'google-ai-studio/gemini-2.5-flash';
+const DEFAULT_VOICE = 'Dennis';
+const DEFAULT_TTS_MODEL = 'inworld-tts-1.5-mini';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toBuffer(raw: RawData): Buffer {
+  if (typeof raw === 'string') {
+    return Buffer.from(raw);
+  }
+
+  if (raw instanceof ArrayBuffer) {
+    return Buffer.from(raw);
+  }
+
+  if (Array.isArray(raw)) {
+    return Buffer.concat(raw.map((chunk) => toBuffer(chunk)));
+  }
+
+  return Buffer.from(raw);
+}
+
+function parseJsonMessage(raw: RawData): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(toBuffer(raw).toString());
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function extractRealtimeError(message: Record<string, unknown>): {
+  message: string;
+  code?: string;
+  type?: string;
+  eventId?: string;
+} {
+  const upstreamError = isRecord(message.error) ? message.error : null;
+  const errorMessage = typeof upstreamError?.message === 'string'
+    ? upstreamError.message
+    : 'Inworld Realtime API error';
+
+  return {
+    message: errorMessage,
+    code: typeof upstreamError?.code === 'string' ? upstreamError.code : undefined,
+    type: typeof upstreamError?.type === 'string' ? upstreamError.type : undefined,
+    eventId: typeof message.event_id === 'string' ? message.event_id : undefined,
+  };
+}
+
+function createTranscriptEvent(
+  role: 'user' | 'assistant',
+  text: string,
+  final: boolean,
+  message: Record<string, unknown>,
+): RealtimeEvent {
+  return {
+    type: 'transcript',
+    data: {
+      role,
+      text,
+      final,
+      itemId: typeof message.item_id === 'string' ? message.item_id : undefined,
+      responseId: typeof message.response_id === 'string' ? message.response_id : undefined,
+      contentIndex: typeof message.content_index === 'number' ? message.content_index : undefined,
+      outputIndex: typeof message.output_index === 'number' ? message.output_index : undefined,
+    },
+  };
+}
+
+function createAudioEvent(message: Record<string, unknown>): RealtimeEvent | null {
+  if (typeof message.delta !== 'string') {
+    return null;
+  }
+
+  return {
+    type: 'audio',
+    data: {
+      chunk: message.delta,
+      itemId: typeof message.item_id === 'string' ? message.item_id : undefined,
+      responseId: typeof message.response_id === 'string' ? message.response_id : undefined,
+      contentIndex: typeof message.content_index === 'number' ? message.content_index : undefined,
+      outputIndex: typeof message.output_index === 'number' ? message.output_index : undefined,
+    },
+  };
+}
+
+function createErrorEvent(message: string, details?: Record<string, unknown>): RealtimeEvent {
+  return {
+    type: 'error',
+    data: {
+      message,
+      ...details,
+    },
+  };
+}
+
+function sendJson(socket: WebSocket, payload: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.send(JSON.stringify(payload), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  if (socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
+    return;
+  }
+
+  socket.close(code, reason);
+}
+
+async function readErrorResponse(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = await response.clone().json();
+    if (isRecord(body) && isRecord(body.error) && typeof body.error.message === 'string') {
+      return body.error.message;
+    }
+
+    if (isRecord(body) && typeof body.message === 'string') {
+      return body.message;
+    }
+  } catch {
+    // Ignore JSON parsing failures and fall back to raw text.
+  }
+
+  try {
+    const text = await response.clone().text();
+    if (text.trim()) {
+      return text;
+    }
+  } catch {
+    // Ignore text parsing failures.
+  }
+
+  return fallback;
+}
+
+function createSessionKey(): string {
+  return `voice-${Date.now()}-${randomUUID()}`;
+}
+
+function buildSessionUpdate(config: RealtimeSessionConfig): Record<string, unknown> {
+  return {
+    type: 'session.update',
+    session: {
+      type: 'realtime',
+      model: config.model,
+      instructions: config.systemPrompt,
+      output_modalities: ['audio'],
+      audio: {
+        input: {
+          turn_detection: {
+            type: 'semantic_vad',
+            eagerness: 'medium',
+            create_response: true,
+            interrupt_response: true,
+          },
+        },
+        output: {
+          voice: config.voice ?? DEFAULT_VOICE,
+          model: DEFAULT_TTS_MODEL,
+          speed: 1,
+        },
+      },
+    },
+  };
+}
+
+class InworldRealtimeSession implements IRealtimeSession {
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly suppressRemoteSessionEnd: () => void,
+  ) {}
+
+  async sendAudio(chunk: Buffer): Promise<void> {
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('Inworld Realtime session is not open');
+    }
+
+    await sendJson(this.socket, {
+      type: 'input_audio_buffer.append',
+      audio: chunk.toString('base64'),
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closed = true;
+    this.suppressRemoteSessionEnd();
+
+    if (this.socket.readyState === WebSocket.CLOSED) {
+      this.closePromise = Promise.resolve();
+      return this.closePromise;
+    }
+
+    this.closePromise = new Promise((resolve) => {
+      this.socket.once('close', () => {
+        resolve();
+      });
+
+      if (this.socket.readyState === WebSocket.CLOSING) {
+        return;
+      }
+
+      this.socket.close(1000, 'Session closed');
+    });
+
+    return this.closePromise;
+  }
+}
+
+export class InworldRealtimeProvider implements IRealtimeProvider {
+  readonly id = 'inworld-realtime';
+  readonly name = 'Inworld Realtime';
+
+  constructor(private readonly apiKey: string) {}
+
+  async getModels(): Promise<string[]> {
+    const response = await fetch(INWORLD_MODELS_URL, {
+      headers: {
+        Authorization: `Basic ${this.apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      const message = await readErrorResponse(
+        response,
+        `Inworld models API error (${response.status})`,
+      );
+      throw new Error(`Inworld models API error: ${message}`);
+    }
+
+    const body = await response.json();
+    if (!isRecord(body)) {
+      return [DEFAULT_REALTIME_MODEL];
+    }
+
+    const models = new Set<string>();
+    const items = Array.isArray(body.data) ? body.data : [];
+
+    for (const item of items) {
+      if (!isRecord(item) || typeof item.id !== 'string' || !item.id) {
+        continue;
+      }
+
+      models.add(item.id);
+    }
+
+    return models.size > 0 ? [...models].sort() : [DEFAULT_REALTIME_MODEL];
+  }
+
+  async createSession(
+    config: RealtimeSessionConfig,
+    onEvent: (event: RealtimeEvent) => void,
+  ): Promise<IRealtimeSession> {
+    const url = new URL(INWORLD_REALTIME_URL);
+    url.searchParams.set('key', createSessionKey());
+    url.searchParams.set('protocol', 'realtime');
+
+    const socket = new WebSocket(url, {
+      headers: {
+        Authorization: `Basic ${this.apiKey}`,
+      },
+    });
+
+    let session: InworldRealtimeSession | null = null;
+    let startupSettled = false;
+    let remoteSessionEndEnabled = true;
+    let sessionConfigured = false;
+
+    const suppressRemoteSessionEnd = (): void => {
+      remoteSessionEndEnabled = false;
+    };
+
+    return new Promise<IRealtimeSession>((resolve, reject) => {
+      const settleStartup = (
+        kind: 'resolve' | 'reject',
+        payload: IRealtimeSession | Error,
+      ): void => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+
+        if (kind === 'resolve') {
+          resolve(payload as IRealtimeSession);
+          return;
+        }
+
+        reject(payload as Error);
+      };
+
+      const failStartup = (message: string): void => {
+        suppressRemoteSessionEnd();
+        settleStartup('reject', new Error(message));
+        closeSocket(socket, 1011, message);
+      };
+
+      const configureSession = (): void => {
+        if (sessionConfigured) {
+          return;
+        }
+
+        sessionConfigured = true;
+
+        void sendJson(socket, buildSessionUpdate(config)).catch((error) => {
+          sessionConfigured = false;
+          failStartup(getErrorMessage(error, 'Failed to configure Inworld realtime session'));
+        });
+      };
+
+      socket.on('message', (rawMessage) => {
+        const message = parseJsonMessage(rawMessage);
+        if (!message) {
+          onEvent(createErrorEvent(
+            'Invalid JSON event received from Inworld Realtime API',
+            { source: 'inworld' },
+          ));
+          return;
+        }
+
+        switch (message.type) {
+          case 'session.created':
+            configureSession();
+            return;
+
+          case 'session.updated':
+            if (!session) {
+              session = new InworldRealtimeSession(socket, suppressRemoteSessionEnd);
+            }
+
+            settleStartup('resolve', session);
+            return;
+
+          case 'conversation.item.input_audio_transcription.delta':
+            if (typeof message.delta === 'string') {
+              onEvent(createTranscriptEvent('user', message.delta, false, message));
+            }
+            return;
+
+          case 'conversation.item.input_audio_transcription.completed':
+            if (typeof message.transcript === 'string') {
+              onEvent(createTranscriptEvent('user', message.transcript, true, message));
+            }
+            return;
+
+          case 'response.output_audio.delta': {
+            const audioEvent = createAudioEvent(message);
+            if (audioEvent) {
+              onEvent(audioEvent);
+            }
+            return;
+          }
+
+          case 'response.output_audio_transcript.delta':
+            if (typeof message.delta === 'string') {
+              onEvent(createTranscriptEvent('assistant', message.delta, false, message));
+            }
+            return;
+
+          case 'response.output_audio_transcript.done':
+            if (typeof message.transcript === 'string') {
+              onEvent(createTranscriptEvent('assistant', message.transcript, true, message));
+            }
+            return;
+
+          case 'error': {
+            const realtimeError = extractRealtimeError(message);
+            onEvent(createErrorEvent(realtimeError.message, {
+              code: realtimeError.code,
+              source: 'inworld',
+              upstreamType: realtimeError.type,
+              eventId: realtimeError.eventId,
+            }));
+
+            if (!startupSettled) {
+              failStartup(realtimeError.message);
+            }
+            return;
+          }
+
+          default:
+            return;
+        }
+      });
+
+      socket.on('error', (error) => {
+        const message = getErrorMessage(error, 'Inworld Realtime websocket error');
+        onEvent(createErrorEvent(message, { source: 'inworld' }));
+
+        if (!startupSettled) {
+          failStartup(message);
+        }
+      });
+
+      socket.on('close', (code, reason) => {
+        const closeReason = toBuffer(reason).toString();
+
+        if (!startupSettled) {
+          settleStartup(
+            'reject',
+            new Error(
+              closeReason || `Inworld Realtime socket closed before session was ready (${code})`,
+            ),
+          );
+          return;
+        }
+
+        if (remoteSessionEndEnabled) {
+          onEvent({
+            type: 'session_end',
+            data: {
+              code,
+              reason: closeReason,
+            },
+          });
+        }
+      });
+    });
+  }
+}

--- a/backend/src/providers/realtime/registry.ts
+++ b/backend/src/providers/realtime/registry.ts
@@ -1,8 +1,11 @@
 import type { IRealtimeProvider } from './types.js';
+import { InworldRealtimeProvider } from './inworld.js';
 
 export type RealtimeProviderConstructor = new (apiKey: string) => IRealtimeProvider;
 
-const PROVIDERS: Record<string, RealtimeProviderConstructor> = {};
+const PROVIDERS: Record<string, RealtimeProviderConstructor> = {
+  'inworld-realtime': InworldRealtimeProvider,
+};
 
 export function createRealtimeProvider(providerId: string, apiKey: string): IRealtimeProvider {
   const Provider = PROVIDERS[providerId];

--- a/backend/tests/providers/inworld-realtime.test.ts
+++ b/backend/tests/providers/inworld-realtime.test.ts
@@ -111,6 +111,7 @@ describe('InworldRealtimeProvider', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -385,6 +386,40 @@ describe('InworldRealtimeProvider', () => {
       },
     });
     expect(socket.close).toHaveBeenCalledWith(1011, 'Invalid model');
+  });
+
+  it('rejects startup when Inworld does not finish the session handshake in time', async () => {
+    vi.useFakeTimers();
+
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'openai/gpt-4.1-nano',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      close: ReturnType<typeof vi.fn>;
+      open(): void;
+    };
+
+    socket.open();
+    const rejection = expect(sessionPromise).rejects.toThrow(
+      'Inworld Realtime session startup timed out after 10000ms',
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await rejection;
+    expect(socket.close).toHaveBeenCalledWith(
+      1011,
+      'Inworld Realtime session startup timed out after 10000ms',
+    );
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
   });
 
   it('does not emit session_end when the session is closed intentionally', async () => {

--- a/backend/tests/providers/inworld-realtime.test.ts
+++ b/backend/tests/providers/inworld-realtime.test.ts
@@ -1,0 +1,418 @@
+const { MockWebSocket, mockSocketInstances } = vi.hoisted(() => {
+  const mockSocketInstances: unknown[] = [];
+
+  class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly url: string;
+    readonly options: Record<string, unknown> | undefined;
+
+    readyState = MockWebSocket.CONNECTING;
+    send = vi.fn((data: string, callback?: (error?: Error) => void) => {
+      callback?.();
+      return true;
+    });
+    close = vi.fn((code?: number, reason?: string) => {
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
+    });
+
+    private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+    constructor(url: string | URL, options?: Record<string, unknown>) {
+      this.url = url.toString();
+      this.options = options;
+      mockSocketInstances.push(this);
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event) ?? [];
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+      return this;
+    }
+
+    once(event: string, listener: (...args: unknown[]) => void): this {
+      const onceListener = (...args: unknown[]) => {
+        this.off(event, onceListener);
+        listener(...args);
+      };
+
+      return this.on(event, onceListener);
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event);
+      if (!listeners) {
+        return this;
+      }
+
+      this.listeners.set(
+        event,
+        listeners.filter((candidate) => candidate !== listener),
+      );
+
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]): boolean {
+      const listeners = this.listeners.get(event);
+      if (!listeners?.length) {
+        return false;
+      }
+
+      for (const listener of [...listeners]) {
+        listener(...args);
+      }
+
+      return true;
+    }
+
+    open(): void {
+      this.readyState = MockWebSocket.OPEN;
+      this.emit('open');
+    }
+
+    emitMessage(message: unknown): void {
+      this.emit('message', Buffer.from(JSON.stringify(message)));
+    }
+  }
+
+  return { MockWebSocket, mockSocketInstances };
+});
+
+vi.mock('ws', () => ({
+  default: MockWebSocket,
+}));
+
+import { InworldRealtimeProvider } from '../../src/providers/realtime/inworld.js';
+import type { RealtimeEvent } from '../../src/providers/realtime/types.js';
+
+function createJsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('InworldRealtimeProvider', () => {
+  const mockFetch = vi.fn<typeof fetch>();
+  let provider: InworldRealtimeProvider;
+
+  beforeEach(() => {
+    mockSocketInstances.length = 0;
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new InworldRealtimeProvider('test-api-key');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('has the expected id and name', () => {
+    expect(provider.id).toBe('inworld-realtime');
+    expect(provider.name).toBe('Inworld Realtime');
+  });
+
+  it('lists available Inworld models from the OpenAI-compatible models endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse({
+      data: [
+        { id: 'openai/gpt-4.1-nano' },
+        { id: 'google-ai-studio/gemini-2.5-flash' },
+        { id: 'openai/gpt-4.1-nano' },
+        { id: 123 },
+        {},
+      ],
+    }));
+
+    await expect(provider.getModels()).resolves.toEqual([
+      'google-ai-studio/gemini-2.5-flash',
+      'openai/gpt-4.1-nano',
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.inworld.ai/v1/models',
+      {
+        headers: {
+          Authorization: 'Basic test-api-key',
+        },
+      },
+    );
+  });
+
+  it('opens an upstream socket, waits for session.created, sends session.update, and streams audio', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'openai/gpt-4.1-nano',
+        systemPrompt: 'Be concise',
+        voice: 'Olivia',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      url: string;
+      options?: Record<string, unknown>;
+      send: ReturnType<typeof vi.fn>;
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    expect(socket).toBeDefined();
+    expect(socket.options).toEqual({
+      headers: {
+        Authorization: 'Basic test-api-key',
+      },
+    });
+
+    const url = new URL(socket.url);
+    expect(url.origin + url.pathname).toBe('wss://api.inworld.ai/api/v1/realtime/session');
+    expect(url.searchParams.get('protocol')).toBe('realtime');
+    expect(url.searchParams.get('key')).toMatch(/^voice-/);
+
+    socket.open();
+    expect(socket.send).not.toHaveBeenCalled();
+
+    socket.emitMessage({
+      type: 'session.created',
+      session: { id: 'session-1' },
+    });
+
+    expect(JSON.parse(socket.send.mock.calls[0]![0] as string)).toEqual({
+      type: 'session.update',
+      session: {
+        type: 'realtime',
+        model: 'openai/gpt-4.1-nano',
+        instructions: 'Be concise',
+        output_modalities: ['audio'],
+        audio: {
+          input: {
+            turn_detection: {
+              type: 'semantic_vad',
+              eagerness: 'medium',
+              create_response: true,
+              interrupt_response: true,
+            },
+          },
+          output: {
+            voice: 'Olivia',
+            model: 'inworld-tts-1.5-mini',
+            speed: 1,
+          },
+        },
+      },
+    });
+
+    socket.emitMessage({
+      type: 'session.updated',
+      session: { id: 'session-1' },
+    });
+
+    const session = await sessionPromise;
+    await session.sendAudio(Buffer.from('hello-audio'));
+
+    expect(JSON.parse(socket.send.mock.calls[1]![0] as string)).toEqual({
+      type: 'input_audio_buffer.append',
+      audio: Buffer.from('hello-audio').toString('base64'),
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('maps upstream transcript, audio, error, and close events into RealtimeEvent', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'google-ai-studio/gemini-2.5-flash',
+        systemPrompt: 'Be helpful',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      readyState: number;
+      open(): void;
+      emit(event: string, ...args: unknown[]): boolean;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ type: 'session.created', session: { id: 'session-1' } });
+    socket.emitMessage({ type: 'session.updated', session: { id: 'session-1' } });
+
+    await sessionPromise;
+
+    socket.emitMessage({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item-user-1',
+      content_index: 0,
+      transcript: 'hello from user',
+    });
+    socket.emitMessage({
+      type: 'response.output_audio.delta',
+      item_id: 'item-assistant-1',
+      response_id: 'resp-1',
+      content_index: 0,
+      output_index: 0,
+      delta: 'YmFzZTY0LWF1ZGlv',
+    });
+    socket.emitMessage({
+      type: 'response.output_audio_transcript.done',
+      item_id: 'item-assistant-1',
+      response_id: 'resp-1',
+      content_index: 0,
+      output_index: 0,
+      transcript: 'assistant reply',
+    });
+    socket.emitMessage({
+      type: 'error',
+      event_id: 'evt-1',
+      error: {
+        message: 'Upstream error',
+        code: 'bad_request',
+        type: 'server_error',
+      },
+    });
+
+    socket.readyState = MockWebSocket.CLOSED;
+    socket.emit('close', 1011, Buffer.from('upstream closed'));
+
+    expect(onEvent.mock.calls).toEqual([
+      [
+        {
+          type: 'transcript',
+          data: {
+            role: 'user',
+            text: 'hello from user',
+            final: true,
+            itemId: 'item-user-1',
+            responseId: undefined,
+            contentIndex: 0,
+            outputIndex: undefined,
+          },
+        },
+      ],
+      [
+        {
+          type: 'audio',
+          data: {
+            chunk: 'YmFzZTY0LWF1ZGlv',
+            itemId: 'item-assistant-1',
+            responseId: 'resp-1',
+            contentIndex: 0,
+            outputIndex: 0,
+          },
+        },
+      ],
+      [
+        {
+          type: 'transcript',
+          data: {
+            role: 'assistant',
+            text: 'assistant reply',
+            final: true,
+            itemId: 'item-assistant-1',
+            responseId: 'resp-1',
+            contentIndex: 0,
+            outputIndex: 0,
+          },
+        },
+      ],
+      [
+        {
+          type: 'error',
+          data: {
+            message: 'Upstream error',
+            code: 'bad_request',
+            source: 'inworld',
+            upstreamType: 'server_error',
+            eventId: 'evt-1',
+          },
+        },
+      ],
+      [
+        {
+          type: 'session_end',
+          data: {
+            code: 1011,
+            reason: 'upstream closed',
+          },
+        },
+      ],
+    ]);
+  });
+
+  it('rejects startup when Inworld returns an error before session.updated', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'openai/gpt-4.1-nano',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      close: ReturnType<typeof vi.fn>;
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ type: 'session.created', session: { id: 'session-1' } });
+    socket.emitMessage({
+      type: 'error',
+      error: {
+        message: 'Invalid model',
+      },
+    });
+
+    await expect(sessionPromise).rejects.toThrow('Invalid model');
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'error',
+      data: {
+        message: 'Invalid model',
+        code: undefined,
+        source: 'inworld',
+        upstreamType: undefined,
+        eventId: undefined,
+      },
+    });
+    expect(socket.close).toHaveBeenCalledWith(1011, 'Invalid model');
+  });
+
+  it('does not emit session_end when the session is closed intentionally', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'openai/gpt-4.1-nano',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0] as {
+      close: ReturnType<typeof vi.fn>;
+      open(): void;
+      emitMessage(message: unknown): void;
+    };
+
+    socket.open();
+    socket.emitMessage({ type: 'session.created', session: { id: 'session-1' } });
+    socket.emitMessage({ type: 'session.updated', session: { id: 'session-1' } });
+
+    const session = await sessionPromise;
+    await session.close();
+
+    expect(socket.close).toHaveBeenCalledWith(1000, 'Session closed');
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
+  });
+});

--- a/backend/tests/providers/realtime-registry.test.ts
+++ b/backend/tests/providers/realtime-registry.test.ts
@@ -3,6 +3,7 @@ import {
   getSupportedRealtimeProviders,
   registerRealtimeProvider,
 } from '../../src/providers/realtime/registry.js';
+import { InworldRealtimeProvider } from '../../src/providers/realtime/inworld.js';
 import type {
   IRealtimeProvider,
   IRealtimeSession,
@@ -53,5 +54,12 @@ describe('Realtime Provider Registry', () => {
     const providers = getSupportedRealtimeProviders();
 
     expect(providers).toContain(providerId);
+  });
+
+  it('creates the built-in Inworld realtime provider', () => {
+    const provider = createRealtimeProvider('inworld-realtime', 'test-key');
+
+    expect(provider).toBeInstanceOf(InworldRealtimeProvider);
+    expect(provider.id).toBe('inworld-realtime');
   });
 });


### PR DESCRIPTION
## Summary
- add `InworldRealtimeProvider` for the backend realtime adapter layer
- register `inworld-realtime` in the realtime provider registry
- add provider and registry tests covering model listing, session setup, event mapping, and intentional shutdown handling

Closes #33.

## Verification
- `npm test` (backend)
- `npm run build` (backend)

## Notes
- Live upstream smoke-testing against Inworld was not run because no Inworld API key was available in the environment.