### PR TITLE
feat: add realtime provider tabs UI

### DIFF
--- a/frontend/src/features/realtime/api/queries.ts
+++ b/frontend/src/features/realtime/api/queries.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../lib/api-client.ts";
+import type { AgentPrompt } from "../../../types/api.ts";
+
+export interface CreateAgentPromptInput {
+  title: string;
+  provider_id: string;
+  language: string;
+  prompt: string;
+}
+
+export const realtimeKeys = {
+  all: ["realtime"] as const,
+  agentPrompts: (providerId: string | null = null) =>
+    [...realtimeKeys.all, "agent-prompts", providerId ?? "all"] as const,
+  models: (providerId: string) => [...realtimeKeys.all, "models", providerId] as const,
+};
+
+export function useAgentPrompts(providerId: string | null = null) {
+  return useQuery({
+    queryKey: realtimeKeys.agentPrompts(providerId),
+    queryFn: async () => {
+      const prompts = await api.get<AgentPrompt[]>("/agent-prompts");
+
+      if (!providerId) {
+        return prompts;
+      }
+
+      return prompts.filter((prompt) => prompt.provider_id === providerId);
+    },
+  });
+}
+
+export function useCreateAgentPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateAgentPromptInput) =>
+      api.post<AgentPrompt>("/agent-prompts", input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [...realtimeKeys.all, "agent-prompts"],
+      });
+    },
+  });
+}
+
+export function useRealtimeModels(providerId: string | null) {
+  return useQuery({
+    queryKey: realtimeKeys.models(providerId ?? ""),
+    queryFn: () => api.get<string[]>(`/realtime/${providerId}/models`),
+    enabled: providerId !== null && providerId.length > 0,
+  });
+}

--- a/frontend/src/features/realtime/components/ElevenLabsTab.tsx
+++ b/frontend/src/features/realtime/components/ElevenLabsTab.tsx
@@ -1,0 +1,10 @@
+import { RealtimeProviderTab } from "./RealtimeProviderTab.tsx";
+
+export function ElevenLabsTab() {
+  return (
+    <RealtimeProviderTab
+      providerId="elevenlabs-realtime"
+      providerLabel="ElevenLabs"
+    />
+  );
+}

--- a/frontend/src/features/realtime/components/GeminiTab.tsx
+++ b/frontend/src/features/realtime/components/GeminiTab.tsx
@@ -1,0 +1,10 @@
+import { RealtimeProviderTab } from "./RealtimeProviderTab.tsx";
+
+export function GeminiTab() {
+  return (
+    <RealtimeProviderTab
+      providerId="gemini-realtime"
+      providerLabel="Gemini"
+    />
+  );
+}

--- a/frontend/src/features/realtime/components/InworldTab.tsx
+++ b/frontend/src/features/realtime/components/InworldTab.tsx
@@ -1,0 +1,10 @@
+import { RealtimeProviderTab } from "./RealtimeProviderTab.tsx";
+
+export function InworldTab() {
+  return (
+    <RealtimeProviderTab
+      providerId="inworld-realtime"
+      providerLabel="Inworld"
+    />
+  );
+}

--- a/frontend/src/features/realtime/components/OpenAiTab.tsx
+++ b/frontend/src/features/realtime/components/OpenAiTab.tsx
@@ -1,0 +1,10 @@
+import { RealtimeProviderTab } from "./RealtimeProviderTab.tsx";
+
+export function OpenAiTab() {
+  return (
+    <RealtimeProviderTab
+      providerId="openai-realtime"
+      providerLabel="OpenAI"
+    />
+  );
+}

--- a/frontend/src/features/realtime/components/RealtimePage.test.tsx
+++ b/frontend/src/features/realtime/components/RealtimePage.test.tsx
@@ -1,0 +1,197 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RealtimePage } from "./RealtimePage.tsx";
+
+const promptsByProvider: Record<string, Array<{
+  created_at: string;
+  created_by: null;
+  id: number;
+  language: string;
+  prompt: string;
+  provider_id: string;
+  title: string;
+}>> = {
+  "openai-realtime": [
+    {
+      id: 1,
+      title: "OpenAI support agent",
+      provider_id: "openai-realtime",
+      language: "en-US",
+      prompt: "Act as a concise technical support agent.",
+      created_by: null,
+      created_at: "2026-04-07T09:00:00.000Z",
+    },
+  ],
+  "gemini-realtime": [
+    {
+      id: 2,
+      title: "Gemini coach",
+      provider_id: "gemini-realtime",
+      language: "en-US",
+      prompt: "Act as a calm pronunciation coach.",
+      created_by: null,
+      created_at: "2026-04-07T09:10:00.000Z",
+    },
+  ],
+  "elevenlabs-realtime": [],
+  "inworld-realtime": [],
+};
+
+const modelsByProvider: Record<string, string[]> = {
+  "openai-realtime": ["gpt-realtime-mini"],
+  "gemini-realtime": ["gemini-2.5-flash-preview-native-audio-dialog"],
+  "elevenlabs-realtime": ["elevenlabs-conversational-v1"],
+  "inworld-realtime": ["inworld-voice-runtime"],
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RealtimePage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("RealtimePage", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (method === "GET" && url.endsWith("/agent-prompts")) {
+        return jsonResponse(Object.values(promptsByProvider).flat());
+      }
+
+      for (const [providerId, models] of Object.entries(modelsByProvider)) {
+        if (method === "GET" && url.endsWith(`/realtime/${providerId}/models`)) {
+          return jsonResponse(models);
+        }
+      }
+
+      if (method === "POST" && url.endsWith("/agent-prompts")) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          language: string;
+          prompt: string;
+          provider_id: string;
+          title: string;
+        };
+        const nextPrompt = {
+          id: 99,
+          title: body.title,
+          provider_id: body.provider_id,
+          language: body.language,
+          prompt: body.prompt,
+          created_by: null,
+          created_at: "2026-04-07T09:30:00.000Z",
+        };
+        promptsByProvider[body.provider_id] = [
+          nextPrompt,
+          ...promptsByProvider[body.provider_id],
+        ];
+        return jsonResponse(nextPrompt, 201);
+      }
+
+      return jsonResponse(
+        {
+          statusCode: 404,
+          error: "Not Found",
+          message: `Unhandled request: ${method} ${url}`,
+        },
+        404,
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+
+    promptsByProvider["openai-realtime"] = [
+      {
+        id: 1,
+        title: "OpenAI support agent",
+        provider_id: "openai-realtime",
+        language: "en-US",
+        prompt: "Act as a concise technical support agent.",
+        created_by: null,
+        created_at: "2026-04-07T09:00:00.000Z",
+      },
+    ];
+    promptsByProvider["gemini-realtime"] = [
+      {
+        id: 2,
+        title: "Gemini coach",
+        provider_id: "gemini-realtime",
+        language: "en-US",
+        prompt: "Act as a calm pronunciation coach.",
+        created_by: null,
+        created_at: "2026-04-07T09:10:00.000Z",
+      },
+    ];
+    promptsByProvider["elevenlabs-realtime"] = [];
+    promptsByProvider["inworld-realtime"] = [];
+  });
+
+  it("renders OpenAI controls by default and switches to Gemini", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(
+      await screen.findByRole("heading", { name: "Realtime" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("OpenAI Session")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("gpt-realtime-mini"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Gemini" }));
+
+    expect(await screen.findByText("Gemini Session")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("gemini-2.5-flash-preview-native-audio-dialog"),
+    ).toBeInTheDocument();
+  });
+
+  it("creates a new agent prompt inline for the active provider", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(screen.getByRole("tab", { name: "ElevenLabs" }));
+    await screen.findByText("ElevenLabs Session");
+    await user.click(screen.getByRole("button", { name: "Create Prompt" }));
+    await user.type(screen.getByLabelText("Prompt title"), "Sales rep");
+    await user.clear(screen.getByLabelText("Language"));
+    await user.type(screen.getByLabelText("Language"), "en-US");
+    await user.type(
+      screen.getByLabelText("Prompt body"),
+      "Act as a polite sales representative.",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Prompt" }));
+
+    expect((await screen.findAllByText("Sales rep")).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/realtime/components/RealtimePage.tsx
+++ b/frontend/src/features/realtime/components/RealtimePage.tsx
@@ -1,0 +1,48 @@
+import { Tabs } from "../../../components/ui/Tabs.tsx";
+import { ElevenLabsTab } from "./ElevenLabsTab.tsx";
+import { GeminiTab } from "./GeminiTab.tsx";
+import { InworldTab } from "./InworldTab.tsx";
+import { OpenAiTab } from "./OpenAiTab.tsx";
+
+type RealtimeProviderTabId = "openai" | "gemini" | "elevenlabs" | "inworld";
+
+const realtimeTabs: ReadonlyArray<{
+  id: RealtimeProviderTabId;
+  label: string;
+}> = [
+  { id: "openai", label: "OpenAI" },
+  { id: "gemini", label: "Gemini" },
+  { id: "elevenlabs", label: "ElevenLabs" },
+  { id: "inworld", label: "Inworld" },
+];
+
+export function RealtimePage() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-gray-900">Realtime</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Compare live voice-agent sessions across all supported realtime
+          providers. Each tab keeps its own model lookup, agent prompts, session
+          controls, microphone capture, and transcript stream.
+        </p>
+      </div>
+
+      <Tabs defaultTab="openai" tabs={realtimeTabs}>
+        {(activeTab) => {
+          switch (activeTab) {
+            case "gemini":
+              return <GeminiTab />;
+            case "elevenlabs":
+              return <ElevenLabsTab />;
+            case "inworld":
+              return <InworldTab />;
+            case "openai":
+            default:
+              return <OpenAiTab />;
+          }
+        }}
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
+++ b/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
@@ -1,0 +1,110 @@
+import { useEffect } from "react";
+import {
+  useCreateAgentPrompt,
+  useAgentPrompts,
+  useRealtimeModels,
+} from "../api/queries.ts";
+import { useMicrophone } from "../hooks/useMicrophone.ts";
+import { useRealtimeSession } from "../hooks/useRealtimeSession.ts";
+import {
+  SessionControls,
+  type CreatePromptDraft,
+} from "./SessionControls.tsx";
+import { TranscriptionPanel } from "./TranscriptionPanel.tsx";
+
+interface RealtimeProviderTabProps {
+  providerId: string;
+  providerLabel: string;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function RealtimeProviderTab({
+  providerId,
+  providerLabel,
+}: RealtimeProviderTabProps) {
+  const promptsQuery = useAgentPrompts(providerId);
+  const createPrompt = useCreateAgentPrompt();
+  const modelsQuery = useRealtimeModels(providerId);
+  const {
+    error: microphoneError,
+    isRecording,
+    start: startMicrophone,
+    stop: stopMicrophone,
+  } = useMicrophone();
+  const session = useRealtimeSession(providerId);
+
+  useEffect(() => {
+    if (!session.isConnected && isRecording) {
+      stopMicrophone();
+    }
+  }, [isRecording, session.isConnected, stopMicrophone]);
+
+  async function handleCreatePrompt(draft: CreatePromptDraft) {
+    return createPrompt.mutateAsync({
+      language: draft.language,
+      prompt: draft.prompt,
+      provider_id: providerId,
+      title: draft.title,
+    });
+  }
+
+  async function handleStart(config: {
+    model: string;
+    systemPrompt: string;
+    voice?: string;
+  }) {
+    await session.connect(config);
+
+    try {
+      await startMicrophone({
+        onChunk: session.sendAudio,
+      });
+    } catch (error) {
+      await session.disconnect();
+      throw error;
+    }
+  }
+
+  async function handleStop() {
+    stopMicrophone();
+    await session.disconnect();
+  }
+
+  return (
+    <div className="space-y-6">
+      <SessionControls
+        error={microphoneError ?? session.error}
+        isActive={session.isConnected}
+        isBusy={session.isConnecting || createPrompt.isPending}
+        isCreatingPrompt={createPrompt.isPending}
+        isModelsLoading={modelsQuery.isPending}
+        isPromptsLoading={promptsQuery.isPending}
+        models={modelsQuery.data ?? []}
+        modelsError={
+          modelsQuery.isError
+            ? getErrorMessage(modelsQuery.error, "Unable to load realtime models.")
+            : null
+        }
+        prompts={promptsQuery.data ?? []}
+        promptsError={
+          promptsQuery.isError
+            ? getErrorMessage(promptsQuery.error, "Unable to load agent prompts.")
+            : null
+        }
+        providerLabel={providerLabel}
+        onCreatePrompt={handleCreatePrompt}
+        onStart={handleStart}
+        onStop={handleStop}
+      />
+
+      <TranscriptionPanel
+        error={microphoneError ?? session.error}
+        isConnected={session.isConnected}
+        transcripts={session.transcripts}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/realtime/components/SessionControls.tsx
+++ b/frontend/src/features/realtime/components/SessionControls.tsx
@@ -1,0 +1,376 @@
+import { useState } from "react";
+import type { AgentPrompt } from "../../../types/api.ts";
+import type { RealtimeConnectConfig } from "../hooks/useRealtimeSession.ts";
+
+export interface CreatePromptDraft {
+  language: string;
+  prompt: string;
+  title: string;
+}
+
+interface SessionControlsProps {
+  error: string | null;
+  isActive: boolean;
+  isBusy: boolean;
+  isCreatingPrompt: boolean;
+  isModelsLoading: boolean;
+  isPromptsLoading: boolean;
+  models: string[];
+  modelsError: string | null;
+  prompts: AgentPrompt[];
+  promptsError: string | null;
+  providerLabel: string;
+  onCreatePrompt: (draft: CreatePromptDraft) => Promise<AgentPrompt>;
+  onStart: (config: RealtimeConnectConfig) => Promise<void>;
+  onStop: () => Promise<void> | void;
+}
+
+function formatModelName(model: string): string {
+  return model.replace(/^models\//, "");
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function SessionControls({
+  error,
+  isActive,
+  isBusy,
+  isCreatingPrompt,
+  isModelsLoading,
+  isPromptsLoading,
+  models,
+  modelsError,
+  prompts,
+  promptsError,
+  providerLabel,
+  onCreatePrompt,
+  onStart,
+  onStop,
+}: SessionControlsProps) {
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [selectedModel, setSelectedModel] = useState("");
+  const [selectedPromptId, setSelectedPromptId] = useState("");
+  const [newPromptTitle, setNewPromptTitle] = useState("");
+  const [newPromptLanguage, setNewPromptLanguage] = useState("en-US");
+  const [newPromptBody, setNewPromptBody] = useState("");
+  const resolvedModel =
+    models.find((model) => model === selectedModel) ?? models[0] ?? "";
+  const resolvedPromptId =
+    prompts.find((prompt) => String(prompt.id) === selectedPromptId)
+      ? selectedPromptId
+      : prompts[0]
+        ? String(prompts[0].id)
+        : "";
+  const selectedPrompt =
+    prompts.find((prompt) => String(prompt.id) === resolvedPromptId) ?? null;
+
+  async function handleStart() {
+    setFormError(null);
+
+    if (!resolvedModel) {
+      setFormError("Select a realtime model before starting the session.");
+      return;
+    }
+
+    if (!selectedPrompt) {
+      setFormError("Select or create an agent prompt before starting.");
+      return;
+    }
+
+    try {
+      await onStart({
+        model: resolvedModel,
+        systemPrompt: selectedPrompt.prompt,
+      });
+    } catch (startError) {
+      setFormError(
+        getErrorMessage(startError, "Unable to start the realtime session."),
+      );
+    }
+  }
+
+  async function handleCreatePrompt() {
+    setCreateError(null);
+
+    const title = newPromptTitle.trim();
+    const language = newPromptLanguage.trim();
+    const prompt = newPromptBody.trim();
+
+    if (!title) {
+      setCreateError("Prompt title is required.");
+      return;
+    }
+
+    if (!language) {
+      setCreateError("Prompt language is required.");
+      return;
+    }
+
+    if (!prompt) {
+      setCreateError("Prompt body is required.");
+      return;
+    }
+
+    try {
+      const createdPrompt = await onCreatePrompt({
+        language,
+        prompt,
+        title,
+      });
+
+      setSelectedPromptId(String(createdPrompt.id));
+      setNewPromptTitle("");
+      setNewPromptLanguage(language);
+      setNewPromptBody("");
+      setIsCreateOpen(false);
+    } catch (createPromptError) {
+      setCreateError(
+        getErrorMessage(createPromptError, "Unable to create the prompt."),
+      );
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {providerLabel} Session
+          </h2>
+          <p className="max-w-2xl text-sm text-gray-600">
+            Choose a model and an agent prompt, then start a live websocket
+            session with microphone streaming and transcript playback.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <span
+            className={[
+              "inline-flex rounded-full px-3 py-1 text-xs font-medium",
+              isActive
+                ? "bg-emerald-100 text-emerald-700"
+                : "bg-gray-100 text-gray-600",
+            ].join(" ")}
+          >
+            {isActive ? "Connected" : "Idle"}
+          </span>
+
+          {isActive ? (
+            <button
+              type="button"
+              className="rounded-xl border border-red-200 px-4 py-2 text-sm font-medium text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => {
+                void onStop();
+              }}
+              disabled={isBusy}
+            >
+              Stop Session
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => {
+                void handleStart();
+              }}
+              disabled={
+                isBusy ||
+                isModelsLoading ||
+                isPromptsLoading ||
+                models.length === 0
+              }
+            >
+              {isBusy ? "Starting..." : "Start Session"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {modelsError ? (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          {modelsError}
+        </div>
+      ) : null}
+
+      {promptsError ? (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          {promptsError}
+        </div>
+      ) : null}
+
+      {formError || error ? (
+        <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {formError ?? error}
+        </div>
+      ) : null}
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <label className="flex flex-col gap-1 text-sm text-gray-600">
+          Model
+          <select
+            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+            value={resolvedModel}
+            onChange={(event) => {
+              setFormError(null);
+              setSelectedModel(event.target.value);
+            }}
+            disabled={isActive || isBusy || isModelsLoading || models.length === 0}
+          >
+            {isModelsLoading ? (
+              <option value="">Loading models...</option>
+            ) : models.length > 0 ? (
+              models.map((model) => (
+                <option key={model} value={model}>
+                  {formatModelName(model)}
+                </option>
+              ))
+            ) : (
+              <option value="">No models available</option>
+            )}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm text-gray-600">
+          Agent Prompt
+          <select
+            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+            value={resolvedPromptId}
+            onChange={(event) => {
+              setFormError(null);
+              setSelectedPromptId(event.target.value);
+            }}
+            disabled={isActive || isBusy || isPromptsLoading || prompts.length === 0}
+          >
+            {isPromptsLoading ? (
+              <option value="">Loading prompts...</option>
+            ) : prompts.length > 0 ? (
+              prompts.map((prompt) => (
+                <option key={prompt.id} value={String(prompt.id)}>
+                  {prompt.title}
+                </option>
+              ))
+            ) : (
+              <option value="">No prompts available</option>
+            )}
+          </select>
+        </label>
+      </div>
+
+      {selectedPrompt ? (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-medium text-gray-900">
+                {selectedPrompt.title}
+              </h3>
+              <p className="text-xs text-gray-500">
+                Language: {selectedPrompt.language}
+              </p>
+            </div>
+
+            <button
+              type="button"
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-white"
+              onClick={() => {
+                setCreateError(null);
+                setIsCreateOpen((current) => !current);
+              }}
+              disabled={isActive || isBusy}
+            >
+              {isCreateOpen ? "Hide Create Form" : "Create Prompt"}
+            </button>
+          </div>
+
+          <p className="mt-3 whitespace-pre-wrap text-sm text-gray-700">
+            {selectedPrompt.prompt}
+          </p>
+        </div>
+      ) : (
+        <div className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+          <span>Create the first prompt for this provider to unlock live sessions.</span>
+          <button
+            type="button"
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-white"
+            onClick={() => {
+              setCreateError(null);
+              setIsCreateOpen(true);
+            }}
+            disabled={isActive || isBusy}
+          >
+            Create Prompt
+          </button>
+        </div>
+      )}
+
+      {isCreateOpen ? (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 p-4">
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_12rem]">
+            <label className="flex flex-col gap-1 text-sm text-gray-600">
+              Prompt title
+              <input
+                type="text"
+                className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                value={newPromptTitle}
+                onChange={(event) => setNewPromptTitle(event.target.value)}
+                disabled={isCreatingPrompt || isActive}
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm text-gray-600">
+              Language
+              <input
+                type="text"
+                className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                value={newPromptLanguage}
+                onChange={(event) => setNewPromptLanguage(event.target.value)}
+                disabled={isCreatingPrompt || isActive}
+              />
+            </label>
+          </div>
+
+          <label className="mt-4 flex flex-col gap-1 text-sm text-gray-600">
+            Prompt body
+            <textarea
+              className="min-h-32 rounded-xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900"
+              value={newPromptBody}
+              onChange={(event) => setNewPromptBody(event.target.value)}
+              disabled={isCreatingPrompt || isActive}
+            />
+          </label>
+
+          {createError ? (
+            <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {createError}
+            </div>
+          ) : null}
+
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              type="button"
+              className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => {
+                void handleCreatePrompt();
+              }}
+              disabled={isCreatingPrompt || isActive}
+            >
+              {isCreatingPrompt ? "Saving..." : "Save Prompt"}
+            </button>
+
+            <button
+              type="button"
+              className="rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => setIsCreateOpen(false)}
+              disabled={isCreatingPrompt}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/features/realtime/components/TranscriptionPanel.tsx
+++ b/frontend/src/features/realtime/components/TranscriptionPanel.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from "react";
+import clsx from "clsx";
+import type { TranscriptEntry } from "../hooks/useRealtimeSession.ts";
+
+interface TranscriptionPanelProps {
+  error: string | null;
+  isConnected: boolean;
+  transcripts: TranscriptEntry[];
+}
+
+function getRoleLabel(role: TranscriptEntry["role"]): string {
+  if (role === "assistant") {
+    return "Agent";
+  }
+
+  if (role === "user") {
+    return "You";
+  }
+
+  return "System";
+}
+
+export function TranscriptionPanel({
+  error,
+  isConnected,
+  transcripts,
+}: TranscriptionPanelProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+
+    element.scrollTop = element.scrollHeight;
+  }, [transcripts]);
+
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Transcription</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Live transcript events from the active realtime websocket session.
+          </p>
+        </div>
+
+        <span
+          className={clsx(
+            "inline-flex rounded-full px-3 py-1 text-xs font-medium",
+            isConnected
+              ? "bg-emerald-100 text-emerald-700"
+              : "bg-gray-100 text-gray-600",
+          )}
+        >
+          {isConnected ? "Live" : "Waiting"}
+        </span>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      <div
+        ref={containerRef}
+        className="mt-4 max-h-[28rem] space-y-3 overflow-y-auto pr-1"
+      >
+        {transcripts.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center text-sm text-gray-500">
+            {isConnected
+              ? "The session is live. Waiting for transcript events..."
+              : "Start a session to stream microphone audio and collect transcripts."}
+          </div>
+        ) : (
+          transcripts.map((transcript) => (
+            <article
+              key={transcript.id}
+              className={clsx(
+                "rounded-xl border px-4 py-3",
+                transcript.role === "user" &&
+                  "border-blue-200 bg-blue-50 text-blue-950",
+                transcript.role === "assistant" &&
+                  "border-gray-200 bg-gray-50 text-gray-900",
+                transcript.role === "system" &&
+                  "border-amber-200 bg-amber-50 text-amber-900",
+              )}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs font-semibold uppercase tracking-wide opacity-75">
+                  {getRoleLabel(transcript.role)}
+                </span>
+                <span className="text-xs opacity-60">
+                  {transcript.final ? "Final" : "Streaming"}
+                </span>
+              </div>
+
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6">
+                {transcript.text}
+              </p>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const TARGET_SAMPLE_RATE = 16_000;
+
+export interface UseMicrophoneStartOptions {
+  mimeType?: string;
+  onChunk?: (chunk: Uint8Array) => void | Promise<void>;
+  timeSliceMs?: number;
+}
+
+interface UseMicrophoneResult {
+  chunks: Uint8Array[];
+  error: string | null;
+  isRecording: boolean;
+  start: (options?: UseMicrophoneStartOptions) => Promise<void>;
+  stop: () => void;
+}
+
+type RecorderWithMimeSupport = typeof MediaRecorder & {
+  isTypeSupported?: (mimeType: string) => boolean;
+};
+
+function getAudioContextConstructor():
+  | (new () => AudioContext)
+  | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window.AudioContext ?? (window as typeof window & {
+    webkitAudioContext?: new () => AudioContext;
+  }).webkitAudioContext;
+}
+
+function chooseRecorderMimeType(preferred?: string): string | undefined {
+  if (typeof MediaRecorder === "undefined") {
+    return undefined;
+  }
+
+  const recorder = MediaRecorder as RecorderWithMimeSupport;
+  const supported = recorder.isTypeSupported?.bind(recorder);
+
+  const candidates = [
+    preferred,
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/ogg;codecs=opus",
+  ].filter((value): value is string => Boolean(value));
+
+  if (!supported) {
+    return candidates[0];
+  }
+
+  return candidates.find((mimeType) => supported(mimeType));
+}
+
+function mixToMono(audioBuffer: AudioBuffer): Float32Array {
+  if (audioBuffer.numberOfChannels === 1) {
+    return audioBuffer.getChannelData(0);
+  }
+
+  const mono = new Float32Array(audioBuffer.length);
+  for (let channel = 0; channel < audioBuffer.numberOfChannels; channel += 1) {
+    const channelData = audioBuffer.getChannelData(channel);
+    for (let index = 0; index < channelData.length; index += 1) {
+      mono[index] += channelData[index] / audioBuffer.numberOfChannels;
+    }
+  }
+
+  return mono;
+}
+
+function downsampleBuffer(
+  input: Float32Array,
+  sourceSampleRate: number,
+  targetSampleRate: number,
+): Float32Array {
+  if (sourceSampleRate === targetSampleRate) {
+    return input;
+  }
+
+  const sampleRateRatio = sourceSampleRate / targetSampleRate;
+  const outputLength = Math.round(input.length / sampleRateRatio);
+  const output = new Float32Array(outputLength);
+
+  let inputIndex = 0;
+  for (let outputIndex = 0; outputIndex < outputLength; outputIndex += 1) {
+    const nextInputIndex = Math.round((outputIndex + 1) * sampleRateRatio);
+    let sum = 0;
+    let count = 0;
+
+    for (
+      let sampleIndex = inputIndex;
+      sampleIndex < nextInputIndex && sampleIndex < input.length;
+      sampleIndex += 1
+    ) {
+      sum += input[sampleIndex];
+      count += 1;
+    }
+
+    output[outputIndex] = count > 0 ? sum / count : 0;
+    inputIndex = nextInputIndex;
+  }
+
+  return output;
+}
+
+function floatToPcm16(input: Float32Array): Uint8Array {
+  const view = new DataView(new ArrayBuffer(input.length * 2));
+
+  for (let index = 0; index < input.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, input[index]));
+    view.setInt16(
+      index * 2,
+      sample < 0 ? sample * 0x8000 : sample * 0x7fff,
+      true,
+    );
+  }
+
+  return new Uint8Array(view.buffer);
+}
+
+async function convertBlobToPcm16(
+  blob: Blob,
+  audioContext: AudioContext,
+): Promise<Uint8Array> {
+  const sourceBuffer = await blob.arrayBuffer();
+  const decodedBuffer = await audioContext.decodeAudioData(sourceBuffer.slice(0));
+  const mono = mixToMono(decodedBuffer);
+  const resampled = downsampleBuffer(
+    mono,
+    decodedBuffer.sampleRate,
+    TARGET_SAMPLE_RATE,
+  );
+
+  return floatToPcm16(resampled);
+}
+
+export function useMicrophone(): UseMicrophoneResult {
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const chunkHandlerRef = useRef<UseMicrophoneStartOptions["onChunk"]>(undefined);
+
+  const [chunks, setChunks] = useState<Uint8Array[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+
+  const stop = useCallback(() => {
+    const recorder = recorderRef.current;
+    recorderRef.current = null;
+
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop();
+      }
+      streamRef.current = null;
+    }
+
+    setIsRecording(false);
+  }, []);
+
+  const start = useCallback(async (options: UseMicrophoneStartOptions = {}) => {
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.mediaDevices?.getUserMedia ||
+      typeof MediaRecorder === "undefined"
+    ) {
+      setError("Microphone capture is not supported in this browser.");
+      throw new Error("Microphone capture is not supported in this browser.");
+    }
+
+    const AudioContextCtor = getAudioContextConstructor();
+    if (!AudioContextCtor) {
+      setError("Audio processing is not supported in this browser.");
+      throw new Error("Audio processing is not supported in this browser.");
+    }
+
+    stop();
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mimeType = chooseRecorderMimeType(options.mimeType);
+    const recorder = mimeType
+      ? new MediaRecorder(stream, { mimeType })
+      : new MediaRecorder(stream);
+
+    if (!audioContextRef.current) {
+      audioContextRef.current = new AudioContextCtor();
+    }
+
+    chunkHandlerRef.current = options.onChunk;
+    streamRef.current = stream;
+    recorderRef.current = recorder;
+
+    setChunks([]);
+    setError(null);
+    setIsRecording(true);
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size === 0 || !audioContextRef.current) {
+        return;
+      }
+
+      void (async () => {
+        try {
+          const pcmChunk = await convertBlobToPcm16(
+            event.data,
+            audioContextRef.current!,
+          );
+
+          setChunks((currentChunks) => [...currentChunks, pcmChunk]);
+          await chunkHandlerRef.current?.(pcmChunk);
+        } catch (processingError) {
+          const message =
+            processingError instanceof Error
+              ? processingError.message
+              : "Unable to process microphone audio.";
+          setError(message);
+        }
+      })();
+    };
+
+    recorder.onerror = () => {
+      setError("Microphone recording failed.");
+      stop();
+    };
+
+    recorder.onstop = () => {
+      if (streamRef.current) {
+        for (const track of streamRef.current.getTracks()) {
+          track.stop();
+        }
+        streamRef.current = null;
+      }
+
+      recorderRef.current = null;
+      setIsRecording(false);
+    };
+
+    recorder.start(options.timeSliceMs ?? 400);
+  }, [stop]);
+
+  useEffect(() => {
+    return () => {
+      stop();
+
+      if (audioContextRef.current) {
+        void audioContextRef.current.close();
+        audioContextRef.current = null;
+      }
+    };
+  }, [stop]);
+
+  return {
+    chunks,
+    error,
+    isRecording,
+    start,
+    stop,
+  };
+}

--- a/frontend/src/features/realtime/hooks/useRealtimeSession.ts
+++ b/frontend/src/features/realtime/hooks/useRealtimeSession.ts
@@ -1,0 +1,480 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface RealtimeConnectConfig {
+  model: string;
+  systemPrompt: string;
+  voice?: string;
+}
+
+export interface TranscriptEntry {
+  id: string;
+  final: boolean;
+  receivedAt: number;
+  role: "assistant" | "system" | "user";
+  text: string;
+}
+
+interface RealtimeSocketEvent {
+  type?: string;
+  data?: unknown;
+}
+
+interface RealtimeSessionResult {
+  clearTranscripts: () => void;
+  connect: (config: RealtimeConnectConfig) => Promise<void>;
+  disconnect: () => Promise<void>;
+  error: string | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  sendAudio: (chunk: Blob | Uint8Array | ArrayBuffer) => Promise<void>;
+  transcripts: TranscriptEntry[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function createTranscriptId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createWebSocketUrl(providerId: string): string {
+  const url = new URL(`/api/realtime/${providerId}/session`, window.location.origin);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+function parseSampleRate(mimeType?: string): number {
+  if (!mimeType) {
+    return 16_000;
+  }
+
+  const match = mimeType.match(/rate=(\d+)/i);
+  return match ? Number(match[1]) : 16_000;
+}
+
+function pcm16ToWav(pcmBytes: Uint8Array, sampleRate: number): ArrayBuffer {
+  const headerSize = 44;
+  const wavBuffer = new ArrayBuffer(headerSize + pcmBytes.byteLength);
+  const view = new DataView(wavBuffer);
+  const bytesPerSample = 2;
+  const channelCount = 1;
+  const byteRate = sampleRate * channelCount * bytesPerSample;
+
+  const writeAscii = (offset: number, text: string) => {
+    for (let index = 0; index < text.length; index += 1) {
+      view.setUint8(offset + index, text.charCodeAt(index));
+    }
+  };
+
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + pcmBytes.byteLength, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channelCount, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, channelCount * bytesPerSample, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, "data");
+  view.setUint32(40, pcmBytes.byteLength, true);
+  new Uint8Array(wavBuffer, headerSize).set(pcmBytes);
+
+  return wavBuffer;
+}
+
+function decodeBase64Chunk(chunk: string): Uint8Array {
+  const binary = window.atob(chunk);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+
+  return window.btoa(binary);
+}
+
+async function toUint8Array(
+  chunk: Blob | Uint8Array | ArrayBuffer,
+): Promise<Uint8Array> {
+  if (chunk instanceof Uint8Array) {
+    return chunk;
+  }
+
+  if (chunk instanceof ArrayBuffer) {
+    return new Uint8Array(chunk);
+  }
+
+  return new Uint8Array(await chunk.arrayBuffer());
+}
+
+function getErrorMessage(data: unknown, fallback: string): string {
+  if (isRecord(data) && typeof data.message === "string" && data.message.trim()) {
+    return data.message;
+  }
+
+  if (typeof data === "string" && data.trim()) {
+    return data;
+  }
+
+  return fallback;
+}
+
+function appendTranscript(
+  current: TranscriptEntry[],
+  next: Omit<TranscriptEntry, "id" | "receivedAt">,
+): TranscriptEntry[] {
+  if (!next.text.trim()) {
+    return current;
+  }
+
+  const previous = current.at(-1);
+  if (previous && previous.role === next.role && previous.final === false) {
+    return [
+      ...current.slice(0, -1),
+      {
+        ...previous,
+        final: next.final,
+        text: next.text,
+        receivedAt: Date.now(),
+      },
+    ];
+  }
+
+  return [
+    ...current,
+    {
+      ...next,
+      id: createTranscriptId(),
+      receivedAt: Date.now(),
+    },
+  ];
+}
+
+export function useRealtimeSession(providerId: string): RealtimeSessionResult {
+  const socketRef = useRef<WebSocket | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const audioQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const startupPromiseRef = useRef<{
+    reject: (error: Error) => void;
+    resolve: () => void;
+  } | null>(null);
+  const intentionalCloseRef = useRef(false);
+
+  const [error, setError] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [transcripts, setTranscripts] = useState<TranscriptEntry[]>([]);
+
+  const ensureAudioContext = useCallback(() => {
+    if (audioContextRef.current) {
+      return audioContextRef.current;
+    }
+
+    const AudioContextCtor =
+      window.AudioContext ??
+      (window as typeof window & {
+        webkitAudioContext?: new () => AudioContext;
+      }).webkitAudioContext;
+
+    if (!AudioContextCtor) {
+      throw new Error("Audio playback is not supported in this browser.");
+    }
+
+    audioContextRef.current = new AudioContextCtor();
+    return audioContextRef.current;
+  }, []);
+
+  const playAudioChunk = useCallback(async (chunk: string, mimeType?: string) => {
+    audioQueueRef.current = audioQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        const audioContext = ensureAudioContext();
+        if (audioContext.state === "suspended") {
+          await audioContext.resume();
+        }
+
+        const sourceBytes = decodeBase64Chunk(chunk);
+        const sourceBuffer = mimeType?.startsWith("audio/pcm")
+          ? pcm16ToWav(sourceBytes, parseSampleRate(mimeType))
+          : toArrayBuffer(sourceBytes);
+        const audioBuffer = await audioContext.decodeAudioData(sourceBuffer.slice(0));
+        const sourceNode = audioContext.createBufferSource();
+        sourceNode.buffer = audioBuffer;
+        sourceNode.connect(audioContext.destination);
+
+        await new Promise<void>((resolve) => {
+          sourceNode.onended = () => resolve();
+          sourceNode.start(0);
+        });
+      })
+      .catch((playbackError) => {
+        setError(
+          playbackError instanceof Error
+            ? playbackError.message
+            : "Unable to play the realtime audio response.",
+        );
+      });
+
+    await audioQueueRef.current;
+  }, [ensureAudioContext]);
+
+  const rejectStartup = useCallback((message: string) => {
+    if (!startupPromiseRef.current) {
+      return;
+    }
+
+    startupPromiseRef.current.reject(new Error(message));
+    startupPromiseRef.current = null;
+  }, []);
+
+  const resolveStartup = useCallback(() => {
+    if (!startupPromiseRef.current) {
+      return;
+    }
+
+    startupPromiseRef.current.resolve();
+    startupPromiseRef.current = null;
+  }, []);
+
+  const closeSocket = useCallback(async (notifyServer: boolean) => {
+    const socket = socketRef.current;
+    socketRef.current = null;
+
+    if (!socket) {
+      setIsConnected(false);
+      setIsConnecting(false);
+      return;
+    }
+
+    intentionalCloseRef.current = true;
+
+    if (notifyServer && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: "session_end" }));
+    }
+
+    if (
+      socket.readyState === WebSocket.OPEN ||
+      socket.readyState === WebSocket.CONNECTING
+    ) {
+      socket.close(1000, "Client disconnected");
+    }
+
+    setIsConnected(false);
+    setIsConnecting(false);
+  }, []);
+
+  const clearTranscripts = useCallback(() => {
+    setTranscripts([]);
+  }, []);
+
+  const connect = useCallback(async (config: RealtimeConnectConfig) => {
+    await closeSocket(false);
+
+    intentionalCloseRef.current = false;
+    setError(null);
+    setTranscripts([]);
+    setIsConnecting(true);
+    setIsConnected(false);
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = new WebSocket(createWebSocketUrl(providerId));
+      socketRef.current = socket;
+      startupPromiseRef.current = { resolve, reject };
+
+      socket.onopen = () => {
+        if (socketRef.current !== socket) {
+          return;
+        }
+
+        socket.send(
+          JSON.stringify({
+            type: "session_start",
+            data: config,
+          }),
+        );
+      };
+
+      socket.onmessage = (event: MessageEvent<string>) => {
+        if (socketRef.current !== socket) {
+          return;
+        }
+
+        let message: RealtimeSocketEvent;
+        try {
+          message = JSON.parse(event.data) as RealtimeSocketEvent;
+        } catch {
+          setError("Received an invalid realtime event.");
+          rejectStartup("Received an invalid realtime event.");
+          return;
+        }
+
+        switch (message.type) {
+          case "session_start":
+            setIsConnecting(false);
+            setIsConnected(true);
+            setError(null);
+            resolveStartup();
+            return;
+
+          case "transcript": {
+            if (!isRecord(message.data)) {
+              return;
+            }
+
+            const role = message.data.role;
+            const text = message.data.text;
+            const final = message.data.final;
+
+            if (
+              (role === "user" || role === "assistant" || role === "system") &&
+              typeof text === "string"
+            ) {
+              setTranscripts((current) =>
+                appendTranscript(current, {
+                  final: typeof final === "boolean" ? final : true,
+                  role,
+                  text,
+                }),
+              );
+            }
+            return;
+          }
+
+          case "audio":
+            if (
+              isRecord(message.data) &&
+              typeof message.data.chunk === "string"
+            ) {
+              void playAudioChunk(
+                message.data.chunk,
+                typeof message.data.mimeType === "string"
+                  ? message.data.mimeType
+                  : undefined,
+              );
+            }
+            return;
+
+          case "error": {
+            const nextError = getErrorMessage(
+              message.data,
+              "Realtime session error.",
+            );
+            setError(nextError);
+
+            if (startupPromiseRef.current) {
+              rejectStartup(nextError);
+            }
+            return;
+          }
+
+          case "session_end":
+            setIsConnecting(false);
+            setIsConnected(false);
+            if (startupPromiseRef.current) {
+              rejectStartup("The realtime session ended before it was ready.");
+            }
+            if (socket.readyState === WebSocket.OPEN) {
+              socket.close(1000, "Session ended");
+            }
+            return;
+
+          default:
+            return;
+        }
+      };
+
+      socket.onerror = () => {
+        if (socketRef.current !== socket) {
+          return;
+        }
+
+        const nextError = "Unable to connect to the realtime session.";
+        setError(nextError);
+        setIsConnecting(false);
+        setIsConnected(false);
+        rejectStartup(nextError);
+      };
+
+      socket.onclose = (event) => {
+        if (socketRef.current === socket) {
+          socketRef.current = null;
+        } else {
+          return;
+        }
+
+        setIsConnecting(false);
+        setIsConnected(false);
+
+        if (!intentionalCloseRef.current && startupPromiseRef.current) {
+          rejectStartup(
+            event.reason || "The realtime session closed before it was ready.",
+          );
+          return;
+        }
+
+        startupPromiseRef.current = null;
+      };
+    });
+  }, [closeSocket, playAudioChunk, providerId, rejectStartup, resolveStartup]);
+
+  const disconnect = useCallback(async () => {
+    await closeSocket(true);
+  }, [closeSocket]);
+
+  const sendAudio = useCallback(async (chunk: Blob | Uint8Array | ArrayBuffer) => {
+    const socket = socketRef.current;
+
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const bytes = await toUint8Array(chunk);
+    socket.send(
+      JSON.stringify({
+        type: "audio",
+        data: toBase64(bytes),
+      }),
+    );
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      void closeSocket(false);
+
+      if (audioContextRef.current) {
+        void audioContextRef.current.close();
+        audioContextRef.current = null;
+      }
+    };
+  }, [closeSocket]);
+
+  return {
+    clearTranscripts,
+    connect,
+    disconnect,
+    error,
+    isConnected,
+    isConnecting,
+    sendAudio,
+    transcripts,
+  };
+}

--- a/frontend/src/pages/RealtimePage.tsx
+++ b/frontend/src/pages/RealtimePage.tsx
@@ -1,8 +1,0 @@
-export function RealtimePage() {
-  return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900">Realtime</h1>
-      <p className="mt-2 text-gray-600">Configure and test realtime voice agents.</p>
-    </div>
-  );
-}

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -48,6 +48,18 @@ const promptsResponse = [
   },
 ];
 
+const realtimePromptsResponse = [
+  {
+    id: 11,
+    title: "Realtime assistant",
+    provider_id: "openai-realtime",
+    language: "en-US",
+    prompt: "Act as a concise assistant during live calls.",
+    created_by: null,
+    created_at: "2026-04-06T19:00:00.000Z",
+  },
+];
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -121,6 +133,14 @@ beforeEach(() => {
             created_at: "2026-04-06T17:00:00.000Z",
           },
         ]);
+      }
+
+      if (url.endsWith("/api/agent-prompts")) {
+        return jsonResponse(realtimePromptsResponse);
+      }
+
+      if (url.endsWith("/api/realtime/openai-realtime/models")) {
+        return jsonResponse(["gpt-realtime-mini"]);
       }
 
       return jsonResponse(

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,8 +3,8 @@ import { AppLayout } from "./components/layout/AppLayout.tsx";
 import { DatasetsPage } from "./features/datasets/components/DatasetsPage.tsx";
 import { DialogEditor } from "./features/datasets/components/DialogEditor.tsx";
 import { PromptEditor } from "./features/datasets/components/PromptEditor.tsx";
+import { RealtimePage } from "./features/realtime/components/RealtimePage.tsx";
 import { TtsPage } from "./features/tts/components/TtsPage.tsx";
-import { RealtimePage } from "./pages/RealtimePage.tsx";
 import { ProvidersPage } from "./pages/ProvidersPage.tsx";
 
 export function AppRouteTree() {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3000',
         rewrite: (path) => path.replace(/^\/api/, ''),
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
## Summary
- implement the frontend realtime feature module with provider-specific tabs for OpenAI, Gemini, ElevenLabs, and Inworld
- add realtime query hooks, microphone capture, websocket session handling, shared session controls, and a live transcription panel
- wire `/realtime` to the new feature page and enable websocket proxying in Vite dev mode

## Testing
- npm run test --workspace=frontend
- npm run build --workspace=frontend
- npm run lint --workspace=frontend

Closes #34