### PR TITLE
feat: add OpenAI realtime provider

### DIFF
--- a/backend/src/providers/realtime/openai.ts
+++ b/backend/src/providers/realtime/openai.ts
@@ -123,6 +123,14 @@ function sendJson(socket: WebSocket, payload: Record<string, unknown>): Promise<
   });
 }
 
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  if (socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
+    return;
+  }
+
+  socket.close(code, reason);
+}
+
 function buildSessionUpdate(config: RealtimeSessionConfig): Record<string, unknown> {
   const session: Record<string, unknown> = {
     type: 'realtime',
@@ -280,12 +288,15 @@ export class OpenAIRealtimeProvider implements IRealtimeProvider {
         reject(payload as Error);
       };
 
+      const failStartup = (message: string): void => {
+        suppressRemoteSessionEnd();
+        settleStartup('reject', new Error(message));
+        closeSocket(socket, 1011, message);
+      };
+
       socket.on('open', () => {
         void sendJson(socket, buildSessionUpdate(config)).catch((error) => {
-          settleStartup(
-            'reject',
-            new Error(getErrorMessage(error, 'Failed to configure OpenAI Realtime session')),
-          );
+          failStartup(getErrorMessage(error, 'Failed to configure OpenAI Realtime session'));
         });
       });
 
@@ -366,7 +377,7 @@ export class OpenAIRealtimeProvider implements IRealtimeProvider {
             }));
 
             if (!startupSettled) {
-              settleStartup('reject', new Error(realtimeError.message));
+              failStartup(realtimeError.message);
             }
             return;
           }
@@ -381,7 +392,7 @@ export class OpenAIRealtimeProvider implements IRealtimeProvider {
         onEvent(createErrorEvent(message, { source: 'openai' }));
 
         if (!startupSettled) {
-          settleStartup('reject', new Error(message));
+          failStartup(message);
         }
       });
 

--- a/backend/src/providers/realtime/openai.ts
+++ b/backend/src/providers/realtime/openai.ts
@@ -1,0 +1,413 @@
+import OpenAI from 'openai';
+import WebSocket, { type RawData } from 'ws';
+import type { IRealtimeProvider, IRealtimeSession, RealtimeEvent, RealtimeSessionConfig } from './types.js';
+
+const REALTIME_MODEL_PREFIXES = [
+  'gpt-realtime',
+  'gpt-4o-realtime-preview',
+  'gpt-audio',
+] as const;
+
+const DEFAULT_INPUT_TRANSCRIPTION_MODEL = 'gpt-4o-mini-transcribe';
+const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toBuffer(raw: RawData): Buffer {
+  if (typeof raw === 'string') {
+    return Buffer.from(raw);
+  }
+
+  if (raw instanceof ArrayBuffer) {
+    return Buffer.from(raw);
+  }
+
+  if (Array.isArray(raw)) {
+    return Buffer.concat(raw.map((chunk) => toBuffer(chunk)));
+  }
+
+  return Buffer.from(raw);
+}
+
+function parseJsonMessage(raw: RawData): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(toBuffer(raw).toString());
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function extractRealtimeError(message: Record<string, unknown>): {
+  message: string;
+  code?: string;
+  type?: string;
+  eventId?: string;
+} {
+  const upstreamError = isRecord(message.error) ? message.error : null;
+  const errorMessage = typeof upstreamError?.message === 'string'
+    ? upstreamError.message
+    : 'OpenAI Realtime API error';
+
+  return {
+    message: errorMessage,
+    code: typeof upstreamError?.code === 'string' ? upstreamError.code : undefined,
+    type: typeof upstreamError?.type === 'string' ? upstreamError.type : undefined,
+    eventId: typeof message.event_id === 'string' ? message.event_id : undefined,
+  };
+}
+
+function createTranscriptEvent(
+  role: 'user' | 'assistant',
+  text: string,
+  final: boolean,
+  message: Record<string, unknown>,
+): RealtimeEvent {
+  return {
+    type: 'transcript',
+    data: {
+      role,
+      text,
+      final,
+      itemId: typeof message.item_id === 'string' ? message.item_id : undefined,
+      responseId: typeof message.response_id === 'string' ? message.response_id : undefined,
+      contentIndex: typeof message.content_index === 'number' ? message.content_index : undefined,
+      outputIndex: typeof message.output_index === 'number' ? message.output_index : undefined,
+    },
+  };
+}
+
+function createAudioEvent(message: Record<string, unknown>): RealtimeEvent | null {
+  if (typeof message.delta !== 'string') {
+    return null;
+  }
+
+  return {
+    type: 'audio',
+    data: {
+      chunk: message.delta,
+      itemId: typeof message.item_id === 'string' ? message.item_id : undefined,
+      responseId: typeof message.response_id === 'string' ? message.response_id : undefined,
+      contentIndex: typeof message.content_index === 'number' ? message.content_index : undefined,
+      outputIndex: typeof message.output_index === 'number' ? message.output_index : undefined,
+    },
+  };
+}
+
+function createErrorEvent(message: string, details?: Record<string, unknown>): RealtimeEvent {
+  return {
+    type: 'error',
+    data: {
+      message,
+      ...details,
+    },
+  };
+}
+
+function sendJson(socket: WebSocket, payload: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.send(JSON.stringify(payload), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function buildSessionUpdate(config: RealtimeSessionConfig): Record<string, unknown> {
+  const session: Record<string, unknown> = {
+    type: 'realtime',
+    model: config.model,
+    instructions: config.systemPrompt,
+    output_modalities: ['audio'],
+    audio: {
+      input: {
+        format: {
+          type: 'audio/pcm',
+          rate: 24000,
+        },
+        noise_reduction: {
+          type: 'near_field',
+        },
+        transcription: {
+          model: DEFAULT_INPUT_TRANSCRIPTION_MODEL,
+        },
+        turn_detection: {
+          type: 'server_vad',
+          create_response: true,
+          interrupt_response: true,
+        },
+      },
+      output: {
+        format: {
+          type: 'audio/pcm',
+          rate: 24000,
+        },
+      },
+    },
+  };
+
+  const audio = session.audio as { output: Record<string, unknown> };
+  if (config.voice) {
+    audio.output.voice = config.voice;
+  }
+
+  return {
+    type: 'session.update',
+    session,
+  };
+}
+
+class OpenAIRealtimeSession implements IRealtimeSession {
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly suppressRemoteSessionEnd: () => void,
+  ) {}
+
+  async sendAudio(chunk: Buffer): Promise<void> {
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('OpenAI Realtime session is not open');
+    }
+
+    await sendJson(this.socket, {
+      type: 'input_audio_buffer.append',
+      audio: chunk.toString('base64'),
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closed = true;
+    this.suppressRemoteSessionEnd();
+
+    if (this.socket.readyState === WebSocket.CLOSED) {
+      this.closePromise = Promise.resolve();
+      return this.closePromise;
+    }
+
+    this.closePromise = new Promise((resolve) => {
+      this.socket.once('close', () => {
+        resolve();
+      });
+
+      if (this.socket.readyState === WebSocket.CLOSING) {
+        return;
+      }
+
+      this.socket.close(1000, 'Session closed');
+    });
+
+    return this.closePromise;
+  }
+}
+
+export class OpenAIRealtimeProvider implements IRealtimeProvider {
+  readonly id = 'openai-realtime';
+  readonly name = 'OpenAI Realtime';
+
+  private readonly client: OpenAI;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+    this.client = new OpenAI({ apiKey });
+  }
+
+  async getModels(): Promise<string[]> {
+    const models = new Set<string>();
+
+    for await (const model of this.client.models.list()) {
+      if (REALTIME_MODEL_PREFIXES.some((prefix) => model.id.startsWith(prefix))) {
+        models.add(model.id);
+      }
+    }
+
+    return [...models].sort();
+  }
+
+  async createSession(
+    config: RealtimeSessionConfig,
+    onEvent: (event: RealtimeEvent) => void,
+  ): Promise<IRealtimeSession> {
+    const url = new URL(OPENAI_REALTIME_URL);
+    url.searchParams.set('model', config.model);
+
+    const socket = new WebSocket(url, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+
+    let session: OpenAIRealtimeSession | null = null;
+    let startupSettled = false;
+    let remoteSessionEndEnabled = true;
+
+    const suppressRemoteSessionEnd = (): void => {
+      remoteSessionEndEnabled = false;
+    };
+
+    return new Promise<IRealtimeSession>((resolve, reject) => {
+      const settleStartup = (
+        kind: 'resolve' | 'reject',
+        payload: IRealtimeSession | Error,
+      ): void => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+
+        if (kind === 'resolve') {
+          resolve(payload as IRealtimeSession);
+          return;
+        }
+
+        reject(payload as Error);
+      };
+
+      socket.on('open', () => {
+        void sendJson(socket, buildSessionUpdate(config)).catch((error) => {
+          settleStartup(
+            'reject',
+            new Error(getErrorMessage(error, 'Failed to configure OpenAI Realtime session')),
+          );
+        });
+      });
+
+      socket.on('message', (rawMessage) => {
+        const message = parseJsonMessage(rawMessage);
+        if (!message) {
+          onEvent(createErrorEvent('Invalid JSON event received from OpenAI Realtime API'));
+          return;
+        }
+
+        switch (message.type) {
+          case 'session.created':
+            return;
+
+          case 'session.updated': {
+            if (!session) {
+              session = new OpenAIRealtimeSession(socket, suppressRemoteSessionEnd);
+            }
+
+            settleStartup('resolve', session);
+            return;
+          }
+
+          case 'conversation.item.input_audio_transcription.delta': {
+            if (typeof message.delta === 'string') {
+              onEvent(createTranscriptEvent('user', message.delta, false, message));
+            }
+            return;
+          }
+
+          case 'conversation.item.input_audio_transcription.completed': {
+            if (typeof message.transcript === 'string') {
+              onEvent(createTranscriptEvent('user', message.transcript, true, message));
+            }
+            return;
+          }
+
+          case 'conversation.item.input_audio_transcription.failed': {
+            const realtimeError = extractRealtimeError(message);
+            onEvent(createErrorEvent(realtimeError.message, {
+              code: realtimeError.code,
+              source: 'openai',
+              upstreamType: realtimeError.type,
+              eventId: realtimeError.eventId,
+            }));
+            return;
+          }
+
+          case 'response.output_audio.delta': {
+            const audioEvent = createAudioEvent(message);
+            if (audioEvent) {
+              onEvent(audioEvent);
+            }
+            return;
+          }
+
+          case 'response.output_audio_transcript.delta': {
+            if (typeof message.delta === 'string') {
+              onEvent(createTranscriptEvent('assistant', message.delta, false, message));
+            }
+            return;
+          }
+
+          case 'response.output_audio_transcript.done': {
+            if (typeof message.transcript === 'string') {
+              onEvent(createTranscriptEvent('assistant', message.transcript, true, message));
+            }
+            return;
+          }
+
+          case 'error': {
+            const realtimeError = extractRealtimeError(message);
+            onEvent(createErrorEvent(realtimeError.message, {
+              code: realtimeError.code,
+              source: 'openai',
+              upstreamType: realtimeError.type,
+              eventId: realtimeError.eventId,
+            }));
+
+            if (!startupSettled) {
+              settleStartup('reject', new Error(realtimeError.message));
+            }
+            return;
+          }
+
+          default:
+            return;
+        }
+      });
+
+      socket.on('error', (error) => {
+        const message = getErrorMessage(error, 'OpenAI Realtime websocket error');
+        onEvent(createErrorEvent(message, { source: 'openai' }));
+
+        if (!startupSettled) {
+          settleStartup('reject', new Error(message));
+        }
+      });
+
+      socket.on('close', (code, reason) => {
+        const closeReason = reason.toString();
+
+        if (!startupSettled) {
+          settleStartup(
+            'reject',
+            new Error(
+              closeReason || `OpenAI Realtime socket closed before session was ready (${code})`,
+            ),
+          );
+          return;
+        }
+
+        if (remoteSessionEndEnabled) {
+          onEvent({
+            type: 'session_end',
+            data: {
+              code,
+              reason: closeReason,
+            },
+          });
+        }
+      });
+    });
+  }
+}

--- a/backend/src/providers/realtime/registry.ts
+++ b/backend/src/providers/realtime/registry.ts
@@ -2,10 +2,13 @@ import type { IRealtimeProvider } from './types.js';
 import { InworldRealtimeProvider } from './inworld.js';
 import { ElevenLabsRealtimeProvider } from './elevenlabs.js';
 import { GeminiRealtimeProvider } from './gemini.js';
+import { OpenAIRealtimeProvider } from './openai.js';
 
 export type RealtimeProviderConstructor = new (apiKey: string) => IRealtimeProvider;
 
-const PROVIDERS: Record<string, RealtimeProviderConstructor> = {};
+const PROVIDERS: Record<string, RealtimeProviderConstructor> = {
+  'openai-realtime': OpenAIRealtimeProvider,
+};
 
 export function createRealtimeProvider(providerId: string, apiKey: string): IRealtimeProvider {
   const Provider = PROVIDERS[providerId];

--- a/backend/tests/providers/openai-realtime.test.ts
+++ b/backend/tests/providers/openai-realtime.test.ts
@@ -365,6 +365,7 @@ describe('OpenAIRealtimeProvider', () => {
         eventId: undefined,
       },
     });
+    expect(socket.close).toHaveBeenCalledWith(1011, 'Invalid model');
   });
 
   it('does not emit session_end when the session is closed intentionally', async () => {
@@ -385,6 +386,31 @@ describe('OpenAIRealtimeProvider', () => {
     await session.close();
 
     expect(socket.close).toHaveBeenCalledWith(1000, 'Session closed');
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
+  });
+
+  it('closes the upstream socket when session.update cannot be sent', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gpt-realtime',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0];
+    socket.send.mockImplementationOnce((_data: string, callback?: (error?: Error) => void) => {
+      callback?.(new Error('send failed'));
+      return true;
+    });
+
+    socket.open();
+
+    await expect(sessionPromise).rejects.toThrow('send failed');
+    expect(socket.close).toHaveBeenCalledWith(1011, 'send failed');
     expect(onEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'session_end' }),
     );

--- a/backend/tests/providers/openai-realtime.test.ts
+++ b/backend/tests/providers/openai-realtime.test.ts
@@ -1,0 +1,392 @@
+const { MockOpenAI, MockWebSocket, mockSocketInstances } = vi.hoisted(() => {
+  const MockOpenAI = vi.fn();
+  const mockSocketInstances: unknown[] = [];
+
+  class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly url: URL;
+    readonly options: Record<string, unknown>;
+
+    readyState = MockWebSocket.CONNECTING;
+    send = vi.fn((data: string, callback?: (error?: Error) => void) => {
+      callback?.();
+      return true;
+    });
+    close = vi.fn((code?: number, reason?: string) => {
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
+    });
+
+    private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+    constructor(url: URL, options: Record<string, unknown>) {
+      this.url = url;
+      this.options = options;
+      mockSocketInstances.push(this);
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event) ?? [];
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+      return this;
+    }
+
+    once(event: string, listener: (...args: unknown[]) => void): this {
+      const onceListener = (...args: unknown[]) => {
+        this.off(event, onceListener);
+        listener(...args);
+      };
+
+      return this.on(event, onceListener);
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event);
+      if (!listeners) {
+        return this;
+      }
+
+      this.listeners.set(
+        event,
+        listeners.filter((candidate) => candidate !== listener),
+      );
+
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]): boolean {
+      const listeners = this.listeners.get(event);
+      if (!listeners?.length) {
+        return false;
+      }
+
+      for (const listener of [...listeners]) {
+        listener(...args);
+      }
+
+      return true;
+    }
+
+    open(): void {
+      this.readyState = MockWebSocket.OPEN;
+      this.emit('open');
+    }
+
+    emitMessage(message: unknown): void {
+      this.emit('message', Buffer.from(JSON.stringify(message)));
+    }
+  }
+
+  return { MockOpenAI, MockWebSocket, mockSocketInstances };
+});
+
+vi.mock('openai', () => ({
+  default: MockOpenAI,
+}));
+
+vi.mock('ws', () => ({
+  default: MockWebSocket,
+}));
+
+import OpenAI from 'openai';
+import { OpenAIRealtimeProvider } from '../../src/providers/realtime/openai.js';
+import type { RealtimeEvent } from '../../src/providers/realtime/types.js';
+
+const OpenAIMock = vi.mocked(OpenAI);
+
+describe('OpenAIRealtimeProvider', () => {
+  let modelsList: { list: ReturnType<typeof vi.fn> };
+  let provider: OpenAIRealtimeProvider;
+
+  beforeEach(() => {
+    mockSocketInstances.length = 0;
+    modelsList = { list: vi.fn() };
+
+    OpenAIMock.mockImplementation(() => ({
+      models: modelsList,
+    }) as unknown as OpenAI);
+
+    provider = new OpenAIRealtimeProvider('test-api-key');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates the OpenAI client with the provided API key', () => {
+    expect(OpenAIMock).toHaveBeenCalledWith({ apiKey: 'test-api-key' });
+  });
+
+  it('filters realtime-capable models from OpenAI model list', async () => {
+    async function* generateModels() {
+      yield { id: 'gpt-realtime' };
+      yield { id: 'gpt-4o-realtime-preview-2025-06-03' };
+      yield { id: 'gpt-audio-mini' };
+      yield { id: 'gpt-4o' };
+      yield { id: 'whisper-1' };
+      yield { id: 'gpt-realtime' };
+    }
+
+    modelsList.list.mockReturnValue(generateModels());
+
+    await expect(provider.getModels()).resolves.toEqual([
+      'gpt-4o-realtime-preview-2025-06-03',
+      'gpt-audio-mini',
+      'gpt-realtime',
+    ]);
+  });
+
+  it('opens an upstream realtime socket and sends session.update before resolving', async () => {
+    modelsList.list.mockReturnValue((async function* empty() {})());
+
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gpt-realtime',
+        systemPrompt: 'Be concise',
+        voice: 'marin',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0];
+    expect(socket).toBeDefined();
+    expect(socket.url.toString()).toBe('wss://api.openai.com/v1/realtime?model=gpt-realtime');
+    expect(socket.options).toEqual({
+      headers: {
+        Authorization: 'Bearer test-api-key',
+      },
+    });
+
+    socket.open();
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(socket.send.mock.calls[0][0] as string)).toEqual({
+      type: 'session.update',
+      session: {
+        type: 'realtime',
+        model: 'gpt-realtime',
+        instructions: 'Be concise',
+        output_modalities: ['audio'],
+        audio: {
+          input: {
+            format: {
+              type: 'audio/pcm',
+              rate: 24000,
+            },
+            noise_reduction: {
+              type: 'near_field',
+            },
+            transcription: {
+              model: 'gpt-4o-mini-transcribe',
+            },
+            turn_detection: {
+              type: 'server_vad',
+              create_response: true,
+              interrupt_response: true,
+            },
+          },
+          output: {
+            format: {
+              type: 'audio/pcm',
+              rate: 24000,
+            },
+            voice: 'marin',
+          },
+        },
+      },
+    });
+
+    socket.emitMessage({
+      type: 'session.updated',
+      session: {
+        model: 'gpt-realtime',
+      },
+    });
+
+    const session = await sessionPromise;
+    await session.sendAudio(Buffer.from('hello-audio'));
+
+    expect(JSON.parse(socket.send.mock.calls[1][0] as string)).toEqual({
+      type: 'input_audio_buffer.append',
+      audio: Buffer.from('hello-audio').toString('base64'),
+    });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('maps upstream transcript, audio, error, and close events into RealtimeEvent', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gpt-realtime-mini',
+        systemPrompt: 'Be helpful',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0];
+    socket.open();
+    socket.emitMessage({ type: 'session.updated', session: { model: 'gpt-realtime-mini' } });
+
+    await sessionPromise;
+
+    socket.emitMessage({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item-user-1',
+      content_index: 0,
+      transcript: 'hello from user',
+    });
+    socket.emitMessage({
+      type: 'response.output_audio.delta',
+      item_id: 'item-assistant-1',
+      response_id: 'resp-1',
+      content_index: 0,
+      output_index: 0,
+      delta: 'YmFzZTY0LWF1ZGlv',
+    });
+    socket.emitMessage({
+      type: 'response.output_audio_transcript.done',
+      item_id: 'item-assistant-1',
+      response_id: 'resp-1',
+      content_index: 0,
+      output_index: 0,
+      transcript: 'assistant reply',
+    });
+    socket.emitMessage({
+      type: 'error',
+      event_id: 'evt-1',
+      error: {
+        message: 'Upstream error',
+        code: 'bad_request',
+        type: 'invalid_request_error',
+      },
+    });
+
+    socket.readyState = MockWebSocket.CLOSED;
+    socket.emit('close', 1011, Buffer.from('upstream closed'));
+
+    expect(onEvent.mock.calls).toEqual([
+      [
+        {
+          type: 'transcript',
+          data: {
+            role: 'user',
+            text: 'hello from user',
+            final: true,
+            itemId: 'item-user-1',
+            responseId: undefined,
+            contentIndex: 0,
+            outputIndex: undefined,
+          },
+        },
+      ],
+      [
+        {
+          type: 'audio',
+          data: {
+            chunk: 'YmFzZTY0LWF1ZGlv',
+            itemId: 'item-assistant-1',
+            responseId: 'resp-1',
+            contentIndex: 0,
+            outputIndex: 0,
+          },
+        },
+      ],
+      [
+        {
+          type: 'transcript',
+          data: {
+            role: 'assistant',
+            text: 'assistant reply',
+            final: true,
+            itemId: 'item-assistant-1',
+            responseId: 'resp-1',
+            contentIndex: 0,
+            outputIndex: 0,
+          },
+        },
+      ],
+      [
+        {
+          type: 'error',
+          data: {
+            message: 'Upstream error',
+            code: 'bad_request',
+            source: 'openai',
+            upstreamType: 'invalid_request_error',
+            eventId: 'evt-1',
+          },
+        },
+      ],
+      [
+        {
+          type: 'session_end',
+          data: {
+            code: 1011,
+            reason: 'upstream closed',
+          },
+        },
+      ],
+    ]);
+  });
+
+  it('rejects startup when OpenAI returns an error before session.updated', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gpt-realtime',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0];
+    socket.open();
+    socket.emitMessage({
+      type: 'error',
+      error: {
+        message: 'Invalid model',
+      },
+    });
+
+    await expect(sessionPromise).rejects.toThrow('Invalid model');
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'error',
+      data: {
+        message: 'Invalid model',
+        code: undefined,
+        source: 'openai',
+        upstreamType: undefined,
+        eventId: undefined,
+      },
+    });
+  });
+
+  it('does not emit session_end when the session is closed intentionally', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gpt-realtime',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0];
+    socket.open();
+    socket.emitMessage({ type: 'session.updated', session: { model: 'gpt-realtime' } });
+
+    const session = await sessionPromise;
+    await session.close();
+
+    expect(socket.close).toHaveBeenCalledWith(1000, 'Session closed');
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'session_end' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Cherry-pick of PR #63 commits that were merged into `feat/29` **after** `feat/29` was already merged to `main`, so the OpenAI realtime provider never landed in `main`
- Adds `OpenAIRealtimeProvider` — WebSocket adapter for OpenAI Realtime API
- Registers `openai-realtime` in the realtime provider registry
- Includes unit tests (7 passing)

## Details
- Filters realtime-capable OpenAI models from `models.list()`
- Sends `session.update` with PCM 24kHz audio settings, VAD, and input transcription
- Forwards client audio via `input_audio_buffer.append`
- Maps upstream transcript, audio, error, and session end events to the backend realtime contract

## Closes
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)