### PR TITLE
feat: add OpenAI realtime provider

### DIFF
--- a/backend/tests/providers/realtime-registry.test.ts
+++ b/backend/tests/providers/realtime-registry.test.ts
@@ -24,9 +24,11 @@ class TestRealtimeProvider implements IRealtimeProvider {
   }
 
   async createSession(
-    _config: RealtimeSessionConfig,
-    _onEvent: (event: RealtimeEvent) => void,
+    config: RealtimeSessionConfig,
+    onEvent: (event: RealtimeEvent) => void,
   ): Promise<IRealtimeSession> {
+    void config;
+    void onEvent;
     return {
       sendAudio(): void {},
       async close(): Promise<void> {},


### PR DESCRIPTION
## Summary
- Add `OpenAIRealtimeProvider` implementing the `IRealtimeProvider` interface over OpenAI's WebSocket-based Realtime API
- Register the provider in the realtime registry
- Comprehensive tests covering session lifecycle, event mapping, error handling, and startup failures
- Fix lint errors (unused vars) in realtime registry test

## Test plan
- [x] Unit tests pass (`openai-realtime.test.ts`)
- [x] Registry test passes (`realtime-registry.test.ts`)
- [x] Lint clean (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)