### PR TITLE
feat: add Gemini TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Internal tool for testing TTS providers, realtime voice agents, and managing dia
 | Frontend | React 19, Vite 8, TypeScript |
 | Backend | Fastify 5, TypeScript |
 | Database | Supabase (Postgres) or SQLite (local dev) |
-| TTS | Google, ElevenLabs, Inworld |
+| TTS | Google, ElevenLabs, Inworld, Gemini |
 | LLM | OpenAI, Anthropic |
 | Auth | Supabase Auth (production) / single-user (local) |
 
@@ -84,6 +84,15 @@ sound-lab/
       api/
   docs/             Architecture and UI documentation
 ```
+
+## Configuring Gemini TTS
+
+1. Go to [Google AI Studio](https://aistudio.google.com/).
+2. Click **Get API key** → **Create API key** (or visit [aistudio.google.com/apikey](https://aistudio.google.com/apikey)).
+3. Select or create a Google Cloud project, then copy the generated key.
+4. Paste the key into the **Gemini TTS** provider on the Providers page.
+
+> The Gemini API offers a free tier with rate limits. Paid usage requires a billing account linked to the Google Cloud project.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Internal tool for testing TTS providers, realtime voice agents, and managing dia
 | Frontend | React 19, Vite 8, TypeScript |
 | Backend | Fastify 5, TypeScript |
 | Database | Supabase (Postgres) or SQLite (local dev) |
-| TTS | Google, ElevenLabs, Inworld, Gemini |
+| TTS | Google, ElevenLabs, Inworld, OpenAI, Gemini |
 | LLM | OpenAI, Anthropic |
 | Auth | Supabase Auth (production) / single-user (local) |
 

--- a/backend/src/bootstrap/providers.ts
+++ b/backend/src/bootstrap/providers.ts
@@ -11,6 +11,7 @@ export const DEFAULT_PROVIDER_SEEDS: ProviderSeed[] = [
   { id: 'elevenlabs', name: 'ElevenLabs', type: 'tts' },
   { id: 'google', name: 'Google', type: 'tts' },
   { id: 'inworld', name: 'Inworld', type: 'tts' },
+  { id: 'gemini-tts', name: 'Gemini TTS', type: 'tts' },
   { id: 'openai', name: 'OpenAI', type: 'llm' },
   { id: 'anthropic', name: 'Anthropic', type: 'llm' },
   // Provider IDs are globally unique across all types.

--- a/backend/src/providers/tts/gemini.ts
+++ b/backend/src/providers/tts/gemini.ts
@@ -60,12 +60,19 @@ export class GeminiTTSProvider implements ITTSProvider {
   }
 
   async synthesize(opts: ISynthesizeOptions): Promise<Buffer> {
+    if (opts.format && opts.format !== 'wav') {
+      throw new Error(`Gemini TTS only supports wav format, got: ${opts.format}`);
+    }
+
     const model = opts.model ?? DEFAULT_MODEL;
-    const url = `${BASE_URL}/${model}:generateContent?key=${this.apiKey}`;
+    const url = `${BASE_URL}/${model}:generateContent`;
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': this.apiKey,
+      },
       body: JSON.stringify({
         contents: [{ parts: [{ text: opts.text }] }],
         generationConfig: {
@@ -97,9 +104,9 @@ export class GeminiTTSProvider implements ITTSProvider {
 
   async validateCredentials(): Promise<boolean> {
     try {
-      const response = await fetch(
-        `${BASE_URL}/${DEFAULT_MODEL}?key=${this.apiKey}`,
-      );
+      const response = await fetch(`${BASE_URL}/${DEFAULT_MODEL}`, {
+        headers: { 'x-goog-api-key': this.apiKey },
+      });
       return response.ok;
     } catch {
       return false;

--- a/backend/src/providers/tts/gemini.ts
+++ b/backend/src/providers/tts/gemini.ts
@@ -13,14 +13,9 @@ const VOICE_NAMES = [
   'Zubenelgenubi', 'Vindemiatrix', 'Sadachbia', 'Sadaltager', 'Sulafat',
 ] as const;
 
-/** Capitalize first letter: 'kore' → 'Kore'. Gemini API requires original casing. */
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-}
-
 function buildStaticVoices(): IVoice[] {
   return VOICE_NAMES.map((name) => ({
-    id: name.toLowerCase(),
+    id: name,
     name,
     language: 'multi',
     gender: undefined,
@@ -77,7 +72,7 @@ export class GeminiTTSProvider implements ITTSProvider {
           responseModalities: ['AUDIO'],
           speechConfig: {
             voiceConfig: {
-              prebuiltVoiceConfig: { voiceName: capitalize(opts.voiceId) },
+              prebuiltVoiceConfig: { voiceName: opts.voiceId },
             },
           },
         },

--- a/backend/src/providers/tts/gemini.ts
+++ b/backend/src/providers/tts/gemini.ts
@@ -1,0 +1,108 @@
+import type { ITTSProvider, IVoice, ISynthesizeOptions } from './types.js';
+
+const BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+const DEFAULT_MODEL = 'gemini-2.5-flash-preview-tts';
+const MODELS = ['gemini-2.5-flash-preview-tts', 'gemini-2.5-pro-preview-tts'] as const;
+
+const VOICE_NAMES = [
+  'Zephyr', 'Puck', 'Charon', 'Kore', 'Fenrir',
+  'Leda', 'Orus', 'Aoede', 'Callirrhoe', 'Autonoe',
+  'Enceladus', 'Iapetus', 'Umbriel', 'Algieba', 'Despina',
+  'Erinome', 'Algenib', 'Rasalgethi', 'Laomedeia', 'Achernar',
+  'Alnilam', 'Schedar', 'Gacrux', 'Pulcherrima', 'Achird',
+  'Zubenelgenubi', 'Vindemiatrix', 'Sadachbia', 'Sadaltager', 'Sulafat',
+] as const;
+
+function buildStaticVoices(): IVoice[] {
+  return VOICE_NAMES.map((name) => ({
+    id: name.toLowerCase(),
+    name,
+    language: 'multi',
+    gender: undefined,
+    description: undefined,
+    previewUrl: undefined,
+    providerMeta: { models: [...MODELS] },
+  }));
+}
+
+/** Prepend a 44-byte WAV header to raw PCM 16-bit mono audio. */
+function wrapPcmInWav(pcm: Buffer, sampleRate: number): Buffer {
+  const header = Buffer.alloc(44);
+  const byteRate = sampleRate * 2; // 16-bit mono = 2 bytes per sample
+  const dataSize = pcm.length;
+  const fileSize = 36 + dataSize;
+
+  header.write('RIFF', 0);
+  header.writeUInt32LE(fileSize, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);      // fmt chunk size
+  header.writeUInt16LE(1, 20);       // PCM format
+  header.writeUInt16LE(1, 22);       // mono
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(2, 32);       // block align (16-bit mono = 2)
+  header.writeUInt16LE(16, 34);      // bits per sample
+  header.write('data', 36);
+  header.writeUInt32LE(dataSize, 40);
+
+  return Buffer.concat([header, pcm]);
+}
+
+export class GeminiTTSProvider implements ITTSProvider {
+  readonly id = 'gemini-tts';
+  readonly name = 'Gemini TTS';
+
+  constructor(private readonly apiKey: string) {}
+
+  async getVoices(): Promise<IVoice[]> {
+    return buildStaticVoices();
+  }
+
+  async synthesize(opts: ISynthesizeOptions): Promise<Buffer> {
+    const model = opts.model ?? DEFAULT_MODEL;
+    const url = `${BASE_URL}/${model}:generateContent?key=${this.apiKey}`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: opts.text }] }],
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: opts.voiceId },
+            },
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Gemini TTS API error: ${response.status} ${body}`);
+    }
+
+    const json = await response.json();
+    const audioData = json.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+
+    if (!audioData) {
+      throw new Error('Gemini TTS API error: no audio data in response');
+    }
+
+    const pcm = Buffer.from(audioData, 'base64');
+    return wrapPcmInWav(pcm, 24000);
+  }
+
+  async validateCredentials(): Promise<boolean> {
+    try {
+      const response = await fetch(
+        `${BASE_URL}/${DEFAULT_MODEL}?key=${this.apiKey}`,
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/backend/src/providers/tts/registry.ts
+++ b/backend/src/providers/tts/registry.ts
@@ -2,11 +2,13 @@ import type { ITTSProvider } from './types.js';
 import { ElevenLabsTTSProvider } from './elevenlabs.js';
 import { GoogleTTSProvider } from './google.js';
 import { InworldTTSProvider } from './inworld.js';
+import { GeminiTTSProvider } from './gemini.js';
 
 const PROVIDERS: Record<string, new (apiKey: string) => ITTSProvider> = {
   elevenlabs: ElevenLabsTTSProvider,
   google: GoogleTTSProvider,
   inworld: InworldTTSProvider,
+  'gemini-tts': GeminiTTSProvider,
 };
 
 export function createTTSProvider(providerId: string, apiKey: string): ITTSProvider {

--- a/backend/src/providers/tts/types.ts
+++ b/backend/src/providers/tts/types.ts
@@ -15,6 +15,7 @@ export interface ISynthesizeOptions {
   temperature?: number;
   format?: string;
   sampleRate?: number;
+  model?: string;
 }
 
 export interface ITTSProvider {

--- a/backend/tests/providers/gemini-tts.test.ts
+++ b/backend/tests/providers/gemini-tts.test.ts
@@ -95,4 +95,131 @@ describe('GeminiTTSProvider', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('synthesize', () => {
+    // 4 bytes of fake PCM data, base64-encoded
+    const fakePcm = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+    const fakePcmBase64 = fakePcm.toString('base64');
+
+    function geminiResponse(base64Audio: string) {
+      return new Response(JSON.stringify({
+        candidates: [{
+          content: {
+            parts: [{
+              inlineData: {
+                mimeType: 'audio/L16;rate=24000',
+                data: base64Audio,
+              },
+            }],
+          },
+        }],
+      }), { status: 200 });
+    }
+
+    it('sends POST to Gemini generateContent endpoint', async () => {
+      mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
+
+      await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=test-api-key',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('sends correct request body with voice config', async () => {
+      mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
+
+      await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(callBody).toEqual({
+        contents: [{ parts: [{ text: 'Hello' }] }],
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: 'kore' },
+            },
+          },
+        },
+      });
+    });
+
+    it('uses provided model when specified', async () => {
+      mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
+
+      await provider.synthesize({ voiceId: 'kore', text: 'Hello', model: 'gemini-2.5-pro-preview-tts' });
+
+      const url = mockFetch.mock.calls[0][0];
+      expect(url).toContain('gemini-2.5-pro-preview-tts:generateContent');
+    });
+
+    it('returns Buffer with WAV header prepended', async () => {
+      mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
+
+      const result = await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      // 44-byte WAV header + 4 bytes PCM
+      expect(result.length).toBe(48);
+    });
+
+    it('produces valid WAV header', async () => {
+      mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
+
+      const result = await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+
+      // RIFF header
+      expect(result.toString('ascii', 0, 4)).toBe('RIFF');
+      expect(result.readUInt32LE(4)).toBe(36 + fakePcm.length); // file size
+      expect(result.toString('ascii', 8, 12)).toBe('WAVE');
+
+      // fmt chunk
+      expect(result.toString('ascii', 12, 16)).toBe('fmt ');
+      expect(result.readUInt32LE(16)).toBe(16);     // chunk size
+      expect(result.readUInt16LE(20)).toBe(1);       // PCM format
+      expect(result.readUInt16LE(22)).toBe(1);       // mono
+      expect(result.readUInt32LE(24)).toBe(24000);   // sample rate
+      expect(result.readUInt32LE(28)).toBe(48000);   // byte rate (24000 * 2)
+      expect(result.readUInt16LE(32)).toBe(2);       // block align
+      expect(result.readUInt16LE(34)).toBe(16);      // bits per sample
+
+      // data chunk
+      expect(result.toString('ascii', 36, 40)).toBe('data');
+      expect(result.readUInt32LE(40)).toBe(fakePcm.length);
+
+      // actual PCM data after header
+      expect(result.subarray(44)).toEqual(fakePcm);
+    });
+
+    it('throws on non-200 response', async () => {
+      mockFetch.mockResolvedValue(new Response('Bad Request', { status: 400 }));
+
+      await expect(
+        provider.synthesize({ voiceId: 'kore', text: 'Hello' }),
+      ).rejects.toThrow('Gemini TTS API error: 400 Bad Request');
+    });
+
+    it('throws when response has no audio data', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'no audio' }] } }],
+      }), { status: 200 }));
+
+      await expect(
+        provider.synthesize({ voiceId: 'kore', text: 'Hello' }),
+      ).rejects.toThrow('Gemini TTS API error: no audio data in response');
+    });
+
+    it('throws on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        provider.synthesize({ voiceId: 'kore', text: 'Hello' }),
+      ).rejects.toThrow('Network error');
+    });
+  });
 });

--- a/backend/tests/providers/gemini-tts.test.ts
+++ b/backend/tests/providers/gemini-tts.test.ts
@@ -1,0 +1,69 @@
+import { GeminiTTSProvider } from '../../src/providers/tts/gemini.js';
+
+describe('GeminiTTSProvider', () => {
+  let provider: GeminiTTSProvider;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new GeminiTTSProvider('test-api-key');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('id and name', () => {
+    it('has id "gemini-tts"', () => {
+      expect(provider.id).toBe('gemini-tts');
+    });
+
+    it('has name "Gemini TTS"', () => {
+      expect(provider.name).toBe('Gemini TTS');
+    });
+  });
+
+  describe('getVoices', () => {
+    it('returns 30 voices', async () => {
+      const voices = await provider.getVoices();
+      expect(voices).toHaveLength(30);
+    });
+
+    it('does not call fetch', async () => {
+      await provider.getVoices();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('voices have correct structure', async () => {
+      const voices = await provider.getVoices();
+      const zephyr = voices.find((v) => v.id === 'zephyr')!;
+
+      expect(zephyr).toEqual({
+        id: 'zephyr',
+        name: 'Zephyr',
+        language: 'multi',
+        gender: undefined,
+        description: undefined,
+        previewUrl: undefined,
+        providerMeta: {
+          models: ['gemini-2.5-flash-preview-tts', 'gemini-2.5-pro-preview-tts'],
+        },
+      });
+    });
+
+    it('includes all 30 voice names', async () => {
+      const voices = await provider.getVoices();
+      const ids = voices.map((v) => v.id);
+
+      expect(ids).toEqual([
+        'zephyr', 'puck', 'charon', 'kore', 'fenrir',
+        'leda', 'orus', 'aoede', 'callirrhoe', 'autonoe',
+        'enceladus', 'iapetus', 'umbriel', 'algieba', 'despina',
+        'erinome', 'algenib', 'rasalgethi', 'laomedeia', 'achernar',
+        'alnilam', 'schedar', 'gacrux', 'pulcherrima', 'achird',
+        'zubenelgenubi', 'vindemiatrix', 'sadachbia', 'sadaltager', 'sulafat',
+      ]);
+    });
+  });
+});

--- a/backend/tests/providers/gemini-tts.test.ts
+++ b/backend/tests/providers/gemini-tts.test.ts
@@ -66,4 +66,33 @@ describe('GeminiTTSProvider', () => {
       ]);
     });
   });
+
+  describe('validateCredentials', () => {
+    it('returns true when API returns 200', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ name: 'models/gemini-2.5-flash-preview-tts' }), { status: 200 }));
+
+      const result = await provider.validateCredentials();
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts?key=test-api-key',
+      );
+    });
+
+    it('returns false when API returns 401', async () => {
+      mockFetch.mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+      const result = await provider.validateCredentials();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when fetch throws a network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const result = await provider.validateCredentials();
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/backend/tests/providers/gemini-tts.test.ts
+++ b/backend/tests/providers/gemini-tts.test.ts
@@ -37,10 +37,10 @@ describe('GeminiTTSProvider', () => {
 
     it('voices have correct structure', async () => {
       const voices = await provider.getVoices();
-      const zephyr = voices.find((v) => v.id === 'zephyr')!;
+      const zephyr = voices.find((v) => v.id === 'Zephyr')!;
 
       expect(zephyr).toEqual({
-        id: 'zephyr',
+        id: 'Zephyr',
         name: 'Zephyr',
         language: 'multi',
         gender: undefined,
@@ -57,12 +57,12 @@ describe('GeminiTTSProvider', () => {
       const ids = voices.map((v) => v.id);
 
       expect(ids).toEqual([
-        'zephyr', 'puck', 'charon', 'kore', 'fenrir',
-        'leda', 'orus', 'aoede', 'callirrhoe', 'autonoe',
-        'enceladus', 'iapetus', 'umbriel', 'algieba', 'despina',
-        'erinome', 'algenib', 'rasalgethi', 'laomedeia', 'achernar',
-        'alnilam', 'schedar', 'gacrux', 'pulcherrima', 'achird',
-        'zubenelgenubi', 'vindemiatrix', 'sadachbia', 'sadaltager', 'sulafat',
+        'Zephyr', 'Puck', 'Charon', 'Kore', 'Fenrir',
+        'Leda', 'Orus', 'Aoede', 'Callirrhoe', 'Autonoe',
+        'Enceladus', 'Iapetus', 'Umbriel', 'Algieba', 'Despina',
+        'Erinome', 'Algenib', 'Rasalgethi', 'Laomedeia', 'Achernar',
+        'Alnilam', 'Schedar', 'Gacrux', 'Pulcherrima', 'Achird',
+        'Zubenelgenubi', 'Vindemiatrix', 'Sadachbia', 'Sadaltager', 'Sulafat',
       ]);
     });
   });
@@ -119,7 +119,7 @@ describe('GeminiTTSProvider', () => {
     it('sends POST to Gemini generateContent endpoint', async () => {
       mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
 
-      await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+      await provider.synthesize({ voiceId: 'Kore', text: 'Hello' });
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=test-api-key',
@@ -133,7 +133,7 @@ describe('GeminiTTSProvider', () => {
     it('sends correct request body with voice config', async () => {
       mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
 
-      await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+      await provider.synthesize({ voiceId: 'Kore', text: 'Hello' });
 
       const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(callBody).toEqual({
@@ -152,7 +152,7 @@ describe('GeminiTTSProvider', () => {
     it('uses provided model when specified', async () => {
       mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
 
-      await provider.synthesize({ voiceId: 'kore', text: 'Hello', model: 'gemini-2.5-pro-preview-tts' });
+      await provider.synthesize({ voiceId: 'Kore', text: 'Hello', model: 'gemini-2.5-pro-preview-tts' });
 
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('gemini-2.5-pro-preview-tts:generateContent');
@@ -161,7 +161,7 @@ describe('GeminiTTSProvider', () => {
     it('returns Buffer with WAV header prepended', async () => {
       mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
 
-      const result = await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+      const result = await provider.synthesize({ voiceId: 'Kore', text: 'Hello' });
 
       expect(Buffer.isBuffer(result)).toBe(true);
       // 44-byte WAV header + 4 bytes PCM
@@ -171,7 +171,7 @@ describe('GeminiTTSProvider', () => {
     it('produces valid WAV header', async () => {
       mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
 
-      const result = await provider.synthesize({ voiceId: 'kore', text: 'Hello' });
+      const result = await provider.synthesize({ voiceId: 'Kore', text: 'Hello' });
 
       // RIFF header
       expect(result.toString('ascii', 0, 4)).toBe('RIFF');
@@ -200,7 +200,7 @@ describe('GeminiTTSProvider', () => {
       mockFetch.mockResolvedValue(new Response('Bad Request', { status: 400 }));
 
       await expect(
-        provider.synthesize({ voiceId: 'kore', text: 'Hello' }),
+        provider.synthesize({ voiceId: 'Kore', text: 'Hello' }),
       ).rejects.toThrow('Gemini TTS API error: 400 Bad Request');
     });
 
@@ -210,7 +210,7 @@ describe('GeminiTTSProvider', () => {
       }), { status: 200 }));
 
       await expect(
-        provider.synthesize({ voiceId: 'kore', text: 'Hello' }),
+        provider.synthesize({ voiceId: 'Kore', text: 'Hello' }),
       ).rejects.toThrow('Gemini TTS API error: no audio data in response');
     });
 
@@ -218,7 +218,7 @@ describe('GeminiTTSProvider', () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
       await expect(
-        provider.synthesize({ voiceId: 'kore', text: 'Hello' }),
+        provider.synthesize({ voiceId: 'Kore', text: 'Hello' }),
       ).rejects.toThrow('Network error');
     });
   });

--- a/backend/tests/providers/gemini-tts.test.ts
+++ b/backend/tests/providers/gemini-tts.test.ts
@@ -75,7 +75,8 @@ describe('GeminiTTSProvider', () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts?key=test-api-key',
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts',
+        { headers: { 'x-goog-api-key': 'test-api-key' } },
       );
     });
 
@@ -122,10 +123,13 @@ describe('GeminiTTSProvider', () => {
       await provider.synthesize({ voiceId: 'Kore', text: 'Hello' });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=test-api-key',
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': 'test-api-key',
+          },
         }),
       );
     });
@@ -194,6 +198,22 @@ describe('GeminiTTSProvider', () => {
 
       // actual PCM data after header
       expect(result.subarray(44)).toEqual(fakePcm);
+    });
+
+    it('accepts format "wav" without error', async () => {
+      mockFetch.mockResolvedValue(geminiResponse(fakePcmBase64));
+
+      const result = await provider.synthesize({ voiceId: 'Kore', text: 'Hello', format: 'wav' });
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+    });
+
+    it('throws when unsupported format is requested', async () => {
+      await expect(
+        provider.synthesize({ voiceId: 'Kore', text: 'Hello', format: 'mp3' }),
+      ).rejects.toThrow('Gemini TTS only supports wav format, got: mp3');
+
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('throws on non-200 response', async () => {

--- a/backend/tests/providers/registry.test.ts
+++ b/backend/tests/providers/registry.test.ts
@@ -2,6 +2,7 @@ import { createTTSProvider, getSupportedTTSProviders } from '../../src/providers
 import { ElevenLabsTTSProvider } from '../../src/providers/tts/elevenlabs.js';
 import { GoogleTTSProvider } from '../../src/providers/tts/google.js';
 import { InworldTTSProvider } from '../../src/providers/tts/inworld.js';
+import { GeminiTTSProvider } from '../../src/providers/tts/gemini.js';
 
 // Mock Google TTS client so GoogleTTSProvider constructor doesn't need real credentials
 vi.mock('@google-cloud/text-to-speech', () => ({
@@ -43,6 +44,13 @@ describe('TTS Provider Registry', () => {
       expect(provider.id).toBe('inworld');
     });
 
+    it('returns GeminiTTSProvider for "gemini-tts"', () => {
+      const provider = createTTSProvider('gemini-tts', 'test-key');
+
+      expect(provider).toBeInstanceOf(GeminiTTSProvider);
+      expect(provider.id).toBe('gemini-tts');
+    });
+
     it('throws for unsupported provider ID', () => {
       expect(() => createTTSProvider('unknown', 'key')).toThrow(
         'Unsupported TTS provider: unknown',
@@ -57,7 +65,8 @@ describe('TTS Provider Registry', () => {
       expect(providers).toContain('elevenlabs');
       expect(providers).toContain('google');
       expect(providers).toContain('inworld');
-      expect(providers).toHaveLength(3);
+      expect(providers).toContain('gemini-tts');
+      expect(providers).toHaveLength(4);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `GeminiTTSProvider` implementing `ITTSProvider` using the Gemini REST API (`generativelanguage.googleapis.com`)
- 30 static voices (Zephyr, Puck, Kore, etc.), two models (`gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`)
- PCM 16-bit 24kHz response wrapped in WAV header for universal browser compatibility
- Registered in provider registry and bootstrap seeds
- 17 new tests covering identity, voices, credential validation, synthesis, and WAV header correctness

Closes #72

## Test plan

- [x] All 17 Gemini TTS provider tests pass
- [x] All 153 provider tests pass
- [x] Full backend suite passes (392 tests)
- [x] Build succeeds
- [ ] Manual: set Gemini API key on Providers page, synthesize speech on TTS page

🤖 Generated with [Claude Code](https://claude.com/claude-code)