### PR TITLE
Providers: show API key status and validation

### DIFF
--- a/backend/src/db/local/providers.ts
+++ b/backend/src/db/local/providers.ts
@@ -3,6 +3,22 @@ import type { Provider, CreateProvider, UpdateProvider, ProviderType } from '../
 import type { IProviderRepository } from '../interfaces.js';
 import { encrypt, decrypt } from './crypto.js';
 
+type ProviderRow = Omit<Provider, 'enabled' | 'has_key'> & {
+  enabled: number | boolean;
+  has_key: number | boolean;
+};
+
+const PROVIDER_SELECT =
+  'id, name, type, enabled, created_at, (encrypted_key IS NOT NULL) AS has_key';
+
+function mapProvider(row: ProviderRow): Provider {
+  return {
+    ...row,
+    enabled: Boolean(row.enabled),
+    has_key: Boolean(row.has_key),
+  };
+}
+
 export class LocalProviderRepository implements IProviderRepository {
   constructor(
     private db: Database.Database,
@@ -11,21 +27,22 @@ export class LocalProviderRepository implements IProviderRepository {
 
   async list(type?: ProviderType): Promise<Provider[]> {
     if (type) {
-      return this.db
-        .prepare('SELECT id, name, type, enabled, created_at FROM providers WHERE type = ? ORDER BY name')
-        .all(type) as Provider[];
+      const rows = this.db
+        .prepare(`SELECT ${PROVIDER_SELECT} FROM providers WHERE type = ? ORDER BY name`)
+        .all(type) as ProviderRow[];
+      return rows.map(mapProvider);
     }
-    return this.db
-      .prepare('SELECT id, name, type, enabled, created_at FROM providers ORDER BY name')
-      .all() as Provider[];
+    const rows = this.db
+      .prepare(`SELECT ${PROVIDER_SELECT} FROM providers ORDER BY name`)
+      .all() as ProviderRow[];
+    return rows.map(mapProvider);
   }
 
   async getById(id: string): Promise<Provider | null> {
-    return (
-      this.db
-        .prepare('SELECT id, name, type, enabled, created_at FROM providers WHERE id = ?')
-        .get(id) as Provider
-    ) ?? null;
+    const row = this.db
+      .prepare(`SELECT ${PROVIDER_SELECT} FROM providers WHERE id = ?`)
+      .get(id) as ProviderRow | undefined;
+    return row ? mapProvider(row) : null;
   }
 
   async create(data: CreateProvider): Promise<Provider> {
@@ -41,7 +58,7 @@ export class LocalProviderRepository implements IProviderRepository {
     this.db.prepare('UPDATE providers SET name = ?, type = ?, enabled = ? WHERE id = ?').run(
       data.name ?? current.name,
       data.type ?? current.type,
-      data.enabled !== undefined ? (data.enabled ? 1 : 0) : current.enabled,
+      data.enabled !== undefined ? (data.enabled ? 1 : 0) : (current.enabled ? 1 : 0),
       id,
     );
     return (await this.getById(id))!;

--- a/backend/src/db/supabase/providers.ts
+++ b/backend/src/db/supabase/providers.ts
@@ -3,6 +3,20 @@ import type { Provider, CreateProvider, UpdateProvider, ProviderType } from '../
 import type { IProviderRepository } from '../interfaces.js';
 import { encrypt, decrypt } from '../local/crypto.js';
 
+type ProviderRow = Omit<Provider, 'has_key'> & {
+  encrypted_key?: string | null;
+};
+
+const PROVIDER_SELECT = 'id, name, type, enabled, created_at, encrypted_key';
+
+function mapProvider(row: ProviderRow): Provider {
+  const { encrypted_key: _encryptedKey, ...provider } = row;
+  return {
+    ...provider,
+    has_key: Boolean(_encryptedKey),
+  };
+}
+
 export class SupabaseProviderRepository implements IProviderRepository {
   constructor(
     private client: AppSupabaseClient,
@@ -10,28 +24,28 @@ export class SupabaseProviderRepository implements IProviderRepository {
   ) {}
 
   async list(type?: ProviderType): Promise<Provider[]> {
-    let query = this.client.from('providers').select('id, name, type, enabled, created_at').order('name');
+    let query = this.client.from('providers').select(PROVIDER_SELECT).order('name');
     if (type) query = query.eq('type', type);
     const { data, error } = await query;
     if (error) throw error;
-    return data;
+    return data.map((row) => mapProvider(row as ProviderRow));
   }
 
   async getById(id: string): Promise<Provider | null> {
     const { data, error } = await this.client
-      .from('providers').select('id, name, type, enabled, created_at').eq('id', id).single();
+      .from('providers').select(PROVIDER_SELECT).eq('id', id).single();
     if (error) {
       if (error.code === 'PGRST116') return null;
       throw error;
     }
-    return data;
+    return mapProvider(data as ProviderRow);
   }
 
   async create(data: CreateProvider): Promise<Provider> {
     const { data: created, error } = await this.client
-      .from('providers').insert(data).select('id, name, type, enabled, created_at').single();
+      .from('providers').insert(data).select(PROVIDER_SELECT).single();
     if (error) throw error;
-    return created;
+    return mapProvider(created as ProviderRow);
   }
 
   async update(id: string, data: UpdateProvider): Promise<Provider> {
@@ -40,9 +54,9 @@ export class SupabaseProviderRepository implements IProviderRepository {
     if (data.type !== undefined) updates.type = data.type;
     if (data.enabled !== undefined) updates.enabled = data.enabled;
     const { data: updated, error } = await this.client
-      .from('providers').update(updates).eq('id', id).select('id, name, type, enabled, created_at').single();
+      .from('providers').update(updates).eq('id', id).select(PROVIDER_SELECT).single();
     if (error) throw error;
-    return updated;
+    return mapProvider(updated as ProviderRow);
   }
 
   async delete(id: string): Promise<void> {

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -7,6 +7,7 @@ export interface Provider {
   name: string;
   type: ProviderType;
   enabled: boolean;
+  has_key: boolean;
   created_at: string;
 }
 

--- a/backend/src/routes/providers/index.ts
+++ b/backend/src/routes/providers/index.ts
@@ -2,9 +2,10 @@ import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
 import {
   Provider, ProviderTypeQuery, CreateProvider, UpdateProvider,
-  SetKeyBody, GetKeyResponse,
+  SetKeyBody, GetKeyResponse, ProviderKeyTestResponse as ProviderKeyTestResponseSchema,
 } from '../../schemas/provider.js';
 import { StringIdParam, ErrorResponse } from '../../schemas/common.js';
+import { createKeyTestResponse, testProviderKey } from '../../services/provider-key-validation.js';
 
 const providerRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
   // GET /providers?type=tts
@@ -35,7 +36,7 @@ const providerRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
     return reply.status(201).send(provider);
   });
 
-  // PUT /providers/:id/key — registered before /:id to avoid routing conflicts
+  // PUT /providers/:id/key - registered before /:id to avoid routing conflicts
   fastify.put('/:id/key', {
     schema: {
       params: StringIdParam,
@@ -54,7 +55,7 @@ const providerRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
     return reply.status(204).send(null);
   });
 
-  // GET /providers/:id/key — registered before /:id to avoid routing conflicts
+  // GET /providers/:id/key - registered before /:id to avoid routing conflicts
   fastify.get('/:id/key', {
     schema: {
       params: StringIdParam,
@@ -73,6 +74,36 @@ const providerRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
       return reply.notFound(`No API key set for provider ${request.params.id}`);
     }
     return { key };
+  });
+
+  // POST /providers/:id/key/test - registered before /:id to avoid routing conflicts
+  fastify.post('/:id/key/test', {
+    schema: {
+      params: StringIdParam,
+      response: {
+        200: ProviderKeyTestResponseSchema,
+        404: ErrorResponse,
+      },
+    },
+  }, async (request, reply) => {
+    const provider = await fastify.db.providers.getById(request.params.id);
+    if (!provider) {
+      return reply.notFound(`Provider ${request.params.id} not found`);
+    }
+
+    const apiKey = await fastify.db.providers.getDecryptedKey(request.params.id);
+    if (!apiKey) {
+      return createKeyTestResponse(request.params.id, 'not_configured');
+    }
+
+    return testProviderKey(provider, apiKey, {
+      createTTSProvider: fastify.createTTSProvider,
+      createLLMProvider: fastify.createLLMProvider,
+      createRealtimeProvider: fastify.createRealtimeProvider,
+      onValidationError: (event) => {
+        fastify.log.warn(event, 'Provider key validation failed');
+      },
+    });
   });
 
   // GET /providers/:id

--- a/backend/src/schemas/provider.ts
+++ b/backend/src/schemas/provider.ts
@@ -12,6 +12,7 @@ export const Provider = Type.Object({
   name: Type.String(),
   type: ProviderType,
   enabled: Type.Boolean(),
+  has_key: Type.Boolean(),
   created_at: Type.String(),
 });
 export type Provider = Static<typeof Provider>;
@@ -44,3 +45,20 @@ export const GetKeyResponse = Type.Object({
   key: Type.String(),
 });
 export type GetKeyResponse = Static<typeof GetKeyResponse>;
+
+export const ProviderKeyTestStatus = Type.Union([
+  Type.Literal('valid'),
+  Type.Literal('invalid'),
+  Type.Literal('not_configured'),
+  Type.Literal('unsupported'),
+  Type.Literal('error'),
+]);
+export type ProviderKeyTestStatus = Static<typeof ProviderKeyTestStatus>;
+
+export const ProviderKeyTestResponse = Type.Object({
+  provider_id: Type.String(),
+  status: ProviderKeyTestStatus,
+  message: Type.Optional(Type.String()),
+  checked_at: Type.String(),
+});
+export type ProviderKeyTestResponse = Static<typeof ProviderKeyTestResponse>;

--- a/backend/src/services/provider-key-validation.ts
+++ b/backend/src/services/provider-key-validation.ts
@@ -1,0 +1,160 @@
+import type { Provider } from '../db/types.js';
+import type { LLMProviderFactory } from '../plugins/llm.js';
+import type { RealtimeProviderFactory } from '../plugins/realtime.js';
+import type { TTSProviderFactory } from '../plugins/tts.js';
+import type {
+  ProviderKeyTestResponse,
+  ProviderKeyTestStatus,
+} from '../schemas/provider.js';
+
+const KEY_TEST_MESSAGES: Record<ProviderKeyTestStatus, string> = {
+  valid: 'Saved API key is active.',
+  invalid: 'The saved API key was rejected or lacks required access.',
+  not_configured: 'Add an API key before testing this provider.',
+  unsupported: 'This provider does not support key validation yet.',
+  error: 'Unable to verify the key right now. Try again later.',
+};
+
+export interface ProviderKeyValidationDeps {
+  createTTSProvider: TTSProviderFactory;
+  createLLMProvider: LLMProviderFactory;
+  createRealtimeProvider: RealtimeProviderFactory;
+  onValidationError?: (event: {
+    providerId: string;
+    providerType: Provider['type'];
+    status: 'invalid' | 'error';
+  }) => void;
+}
+
+export function createKeyTestResponse(
+  providerId: string,
+  status: ProviderKeyTestStatus,
+): ProviderKeyTestResponse {
+  return {
+    provider_id: providerId,
+    status,
+    message: KEY_TEST_MESSAGES[status],
+    checked_at: new Date().toISOString(),
+  };
+}
+
+function isCredentialFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return [
+    '401',
+    '403',
+    'unauthorized',
+    'forbidden',
+    'apikey',
+    'invalid api key',
+    'invalid key',
+    'invalid credentials',
+    'authentication',
+    'permission',
+    'quota',
+    'expired',
+    'rejected',
+  ].some((needle) => normalized.includes(needle));
+}
+
+function isUnsupportedProviderError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /unsupported .*provider/i.test(message);
+}
+
+function classifyValidationError(
+  provider: Provider,
+  error: unknown,
+  deps: ProviderKeyValidationDeps,
+): ProviderKeyTestResponse {
+  const status = isCredentialFailure(error) ? 'invalid' : 'error';
+  deps.onValidationError?.({
+    providerId: provider.id,
+    providerType: provider.type,
+    status,
+  });
+  return createKeyTestResponse(provider.id, status);
+}
+
+async function testTTSProvider(
+  provider: Provider,
+  apiKey: string,
+  deps: ProviderKeyValidationDeps,
+): Promise<ProviderKeyTestResponse> {
+  let ttsProvider;
+  try {
+    ttsProvider = deps.createTTSProvider(provider.id, apiKey);
+  } catch (error) {
+    return isUnsupportedProviderError(error)
+      ? createKeyTestResponse(provider.id, 'unsupported')
+      : classifyValidationError(provider, error, deps);
+  }
+
+  try {
+    const isValid = await ttsProvider.validateCredentials();
+    return createKeyTestResponse(provider.id, isValid ? 'valid' : 'invalid');
+  } catch (error) {
+    return classifyValidationError(provider, error, deps);
+  }
+}
+
+async function testLLMProvider(
+  provider: Provider,
+  apiKey: string,
+  deps: ProviderKeyValidationDeps,
+): Promise<ProviderKeyTestResponse> {
+  let llmProvider;
+  try {
+    llmProvider = deps.createLLMProvider(provider.id, apiKey);
+  } catch (error) {
+    return isUnsupportedProviderError(error)
+      ? createKeyTestResponse(provider.id, 'unsupported')
+      : classifyValidationError(provider, error, deps);
+  }
+
+  try {
+    const isValid = await llmProvider.validateCredentials();
+    return createKeyTestResponse(provider.id, isValid ? 'valid' : 'invalid');
+  } catch (error) {
+    return classifyValidationError(provider, error, deps);
+  }
+}
+
+async function testRealtimeProvider(
+  provider: Provider,
+  apiKey: string,
+  deps: ProviderKeyValidationDeps,
+): Promise<ProviderKeyTestResponse> {
+  let realtimeProvider;
+  try {
+    realtimeProvider = deps.createRealtimeProvider(provider.id, apiKey);
+  } catch (error) {
+    return isUnsupportedProviderError(error)
+      ? createKeyTestResponse(provider.id, 'unsupported')
+      : classifyValidationError(provider, error, deps);
+  }
+
+  try {
+    await realtimeProvider.getModels();
+    return createKeyTestResponse(provider.id, 'valid');
+  } catch (error) {
+    return classifyValidationError(provider, error, deps);
+  }
+}
+
+export async function testProviderKey(
+  provider: Provider,
+  apiKey: string,
+  deps: ProviderKeyValidationDeps,
+): Promise<ProviderKeyTestResponse> {
+  if (provider.type === 'tts') {
+    return testTTSProvider(provider, apiKey, deps);
+  }
+
+  if (provider.type === 'llm') {
+    return testLLMProvider(provider, apiKey, deps);
+  }
+
+  return testRealtimeProvider(provider, apiKey, deps);
+}

--- a/backend/tests/db/providers.test.ts
+++ b/backend/tests/db/providers.test.ts
@@ -20,9 +20,11 @@ describe('LocalProviderRepository', () => {
       expect(provider.id).toBe('elevenlabs');
       expect(provider.name).toBe('ElevenLabs');
       expect(provider.type).toBe('tts');
+      expect(provider.has_key).toBe(false);
 
       const found = await repo.getById('elevenlabs');
       expect(found?.name).toBe('ElevenLabs');
+      expect(found?.has_key).toBe(false);
     });
 
     it('returns null for non-existent id', async () => {
@@ -44,6 +46,21 @@ describe('LocalProviderRepository', () => {
       const ttsList = await repo.list('tts');
       expect(ttsList).toHaveLength(2);
       expect(ttsList.every(p => p.type === 'tts')).toBe(true);
+    });
+
+    it('includes safe API key presence without exposing encrypted keys', async () => {
+      await repo.create({ id: 'google', name: 'Google', type: 'tts' });
+      await repo.create({ id: 'openai', name: 'OpenAI', type: 'llm' });
+      await repo.setKey('openai', 'sk-secret-key-12345');
+
+      const providers = await repo.list();
+
+      expect(providers).toEqual([
+        expect.objectContaining({ id: 'google', has_key: false }),
+        expect.objectContaining({ id: 'openai', has_key: true }),
+      ]);
+      expect(JSON.stringify(providers)).not.toContain('encrypted_key');
+      expect(JSON.stringify(providers)).not.toContain('sk-secret-key-12345');
     });
   });
 
@@ -69,7 +86,9 @@ describe('LocalProviderRepository', () => {
       await repo.setKey('elevenlabs', 'sk-secret-key-12345');
 
       const decrypted = await repo.getDecryptedKey('elevenlabs');
+      const provider = await repo.getById('elevenlabs');
       expect(decrypted).toBe('sk-secret-key-12345');
+      expect(provider?.has_key).toBe(true);
     });
 
     it('returns null when no key is set', async () => {

--- a/backend/tests/routes/providers.test.ts
+++ b/backend/tests/routes/providers.test.ts
@@ -53,6 +53,22 @@ describe('Provider routes', () => {
       const body = res.json();
       expect(body[0].enabled).toBe(true);
     });
+
+    it('returns safe API key presence without exposing secrets', async () => {
+      await seedProvider('google', 'Google');
+      await seedProvider('openai', 'OpenAI', 'llm');
+      await app.db.providers.setKey('openai', 'sk-secret-key-12345');
+
+      const res = await app.inject({ method: 'GET', url: '/providers' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual([
+        expect.objectContaining({ id: 'google', has_key: false }),
+        expect.objectContaining({ id: 'openai', has_key: true }),
+      ]);
+      expect(res.body).not.toContain('encrypted_key');
+      expect(res.body).not.toContain('sk-secret-key-12345');
+    });
   });
 
   describe('GET /providers/:id', () => {
@@ -222,6 +238,175 @@ describe('Provider routes', () => {
         method: 'GET',
         url: '/providers/elevenlabs/key',
       });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('POST /providers/:id/key/test', () => {
+    it('returns not_configured when the provider has no key', async () => {
+      await seedProvider('elevenlabs', 'ElevenLabs');
+      const createTTSProvider = vi.fn();
+      (app as Record<string, unknown>).createTTSProvider = createTTSProvider;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/elevenlabs/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'elevenlabs',
+        status: 'not_configured',
+        message: 'Add an API key before testing this provider.',
+      });
+      expect(res.json().checked_at).toEqual(expect.any(String));
+      expect(createTTSProvider).not.toHaveBeenCalled();
+    });
+
+    it('validates a saved TTS provider key', async () => {
+      await seedProvider('elevenlabs', 'ElevenLabs');
+      await app.db.providers.setKey('elevenlabs', 'test-api-key');
+      const validateCredentials = vi.fn<() => Promise<boolean>>().mockResolvedValue(true);
+      (app as Record<string, unknown>).createTTSProvider = vi.fn(() => ({
+        id: 'elevenlabs',
+        name: 'ElevenLabs',
+        getVoices: vi.fn(),
+        synthesize: vi.fn(),
+        validateCredentials,
+      }));
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/elevenlabs/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'elevenlabs',
+        status: 'valid',
+        message: 'Saved API key is active.',
+      });
+      expect(validateCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns invalid when the provider rejects a saved key', async () => {
+      await seedProvider('elevenlabs', 'ElevenLabs');
+      await app.db.providers.setKey('elevenlabs', 'test-api-key');
+      (app as Record<string, unknown>).createTTSProvider = vi.fn(() => ({
+        id: 'elevenlabs',
+        name: 'ElevenLabs',
+        getVoices: vi.fn(),
+        synthesize: vi.fn(),
+        validateCredentials: vi.fn<() => Promise<boolean>>().mockResolvedValue(false),
+      }));
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/elevenlabs/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'elevenlabs',
+        status: 'invalid',
+        message: 'The saved API key was rejected or lacks required access.',
+      });
+    });
+
+    it('returns invalid when a supported provider has malformed credentials', async () => {
+      await seedProvider('google', 'Google');
+      await app.db.providers.setKey('google', 'not-json');
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/google/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'google',
+        status: 'invalid',
+        message: 'The saved API key was rejected or lacks required access.',
+      });
+    });
+
+    it('returns unsupported when the provider has no validation adapter', async () => {
+      await seedProvider('unsupported', 'Unsupported');
+      await app.db.providers.setKey('unsupported', 'test-api-key');
+      (app as Record<string, unknown>).createTTSProvider = vi.fn(() => {
+        throw new Error('Unsupported TTS provider: unsupported');
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/unsupported/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'unsupported',
+        status: 'unsupported',
+        message: 'This provider does not support key validation yet.',
+      });
+    });
+
+    it('uses model lookup as realtime provider validation', async () => {
+      await seedProvider('openai-realtime', 'OpenAI Realtime', 'realtime');
+      await app.db.providers.setKey('openai-realtime', 'test-api-key');
+      const getModels = vi.fn<() => Promise<string[]>>().mockResolvedValue(['gpt-realtime']);
+      (app as Record<string, unknown>).createRealtimeProvider = vi.fn(() => ({
+        id: 'openai-realtime',
+        name: 'OpenAI Realtime',
+        getModels,
+        createSession: vi.fn(),
+      }));
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/openai-realtime/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'openai-realtime',
+        status: 'valid',
+        message: 'Saved API key is active.',
+      });
+      expect(getModels).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not expose secrets in validation failure messages', async () => {
+      await seedProvider('openai-realtime', 'OpenAI Realtime', 'realtime');
+      await app.db.providers.setKey('openai-realtime', 'sk-secret-key-12345');
+      (app as Record<string, unknown>).createRealtimeProvider = vi.fn(() => ({
+        id: 'openai-realtime',
+        name: 'OpenAI Realtime',
+        getModels: vi.fn<() => Promise<string[]>>().mockRejectedValue(
+          new Error('network failed with sk-secret-key-12345'),
+        ),
+        createSession: vi.fn(),
+      }));
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/openai-realtime/key/test',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        provider_id: 'openai-realtime',
+        status: 'error',
+        message: 'Unable to verify the key right now. Try again later.',
+      });
+      expect(res.body).not.toContain('sk-secret-key-12345');
+    });
+
+    it('returns 404 for a missing provider', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/providers/missing/key/test',
+      });
+
       expect(res.statusCode).toBe(404);
     });
   });

--- a/frontend/src/features/datasets/components/PromptEditor.tsx
+++ b/frontend/src/features/datasets/components/PromptEditor.tsx
@@ -43,6 +43,7 @@ function getProviderOptions(
       name: currentProviderId,
       type: "tts",
       enabled: false,
+      has_key: false,
       created_at: "",
     },
   ];

--- a/frontend/src/features/providers/api/queries.ts
+++ b/frontend/src/features/providers/api/queries.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../lib/api-client.ts";
-import type { Provider, ProviderType } from "../../../types/api.ts";
+import type { Provider, ProviderKeyTestResponse, ProviderType } from "../../../types/api.ts";
 
 interface UpdateProviderInput {
   id: string;
@@ -19,6 +19,23 @@ export function useProviders(type: ProviderType) {
   });
 }
 
+export function providerKeyTestQueryKey(id: string) {
+  return ["provider-key-test", id] as const;
+}
+
+export function testProviderKey(id: string) {
+  return api.post<ProviderKeyTestResponse>(`/providers/${id}/key/test`);
+}
+
+export function useProviderKeyTest(provider: Pick<Provider, "id" | "has_key">) {
+  return useQuery({
+    queryKey: providerKeyTestQueryKey(provider.id),
+    queryFn: () => testProviderKey(provider.id),
+    enabled: provider.has_key,
+    retry: false,
+  });
+}
+
 export function useUpdateProvider() {
   const queryClient = useQueryClient();
 
@@ -31,7 +48,18 @@ export function useUpdateProvider() {
 }
 
 export function useSetProviderKey() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: ({ id, key }: SetProviderKeyInput) => api.put<void>(`/providers/${id}/key`, { key }),
+    onSuccess: (_data, { id }) => {
+      queryClient.setQueriesData<Provider[]>({ queryKey: ["providers"] }, (providers) => {
+        if (!providers) return providers;
+        return providers.map((provider) => (
+          provider.id === id ? { ...provider, has_key: true } : provider
+        ));
+      });
+      void queryClient.invalidateQueries({ queryKey: ["providers"] });
+    },
   });
 }

--- a/frontend/src/features/providers/components/ProviderCard.tsx
+++ b/frontend/src/features/providers/components/ProviderCard.tsx
@@ -1,18 +1,113 @@
 import { useState } from "react";
 import { ApiError } from "../../../lib/api-client.ts";
-import type { Provider } from "../../../types/api.ts";
-import { useSetProviderKey, useUpdateProvider } from "../api/queries.ts";
+import type { Provider, ProviderKeyTestResponse } from "../../../types/api.ts";
+import { useProviderKeyTest, useSetProviderKey, useUpdateProvider } from "../api/queries.ts";
 import { ApiKeyDialog } from "./ApiKeyDialog.tsx";
 
 interface ProviderCardProps {
   provider: Provider;
 }
 
+type KeyStatusTone = "neutral" | "checking" | "valid" | "invalid" | "error";
+
+interface KeyStatusView {
+  label: string;
+  message: string;
+  tone: KeyStatusTone;
+}
+
+const KEY_STATUS_STYLES: Record<KeyStatusTone, string> = {
+  neutral: "bg-gray-100 text-gray-700",
+  checking: "bg-amber-100 text-amber-800",
+  valid: "bg-green-100 text-green-800",
+  invalid: "bg-red-100 text-red-800",
+  error: "bg-slate-100 text-slate-700",
+};
+
+function resolveKeyStatus(
+  hasConfiguredKey: boolean,
+  isChecking: boolean,
+  response: ProviderKeyTestResponse | undefined,
+  error: unknown,
+): KeyStatusView {
+  if (!hasConfiguredKey) {
+    return {
+      label: "Not configured",
+      message: "Add a key to test it.",
+      tone: "neutral",
+    };
+  }
+
+  if (isChecking) {
+    return {
+      label: "Checking...",
+      message: "Validating the saved key.",
+      tone: "checking",
+    };
+  }
+
+  if (error) {
+    return {
+      label: "Unable to verify",
+      message: "Unable to verify the key right now. Try again later.",
+      tone: "error",
+    };
+  }
+
+  if (response?.status === "valid") {
+    return {
+      label: "Active",
+      message: response.message ?? "Saved API key is active.",
+      tone: "valid",
+    };
+  }
+
+  if (response?.status === "invalid") {
+    return {
+      label: "Problem",
+      message: response.message ?? "The saved API key was rejected or lacks required access.",
+      tone: "invalid",
+    };
+  }
+
+  if (response?.status === "not_configured") {
+    return {
+      label: "Not configured",
+      message: response.message ?? "Add a key to test it.",
+      tone: "neutral",
+    };
+  }
+
+  if (response?.status === "unsupported" || response?.status === "error") {
+    return {
+      label: "Unable to verify",
+      message: response.message ?? "Unable to verify the key right now. Try again later.",
+      tone: "error",
+    };
+  }
+
+  return {
+    label: "Checking...",
+    message: "Validation is queued.",
+    tone: "checking",
+  };
+}
+
 export function ProviderCard({ provider }: ProviderCardProps) {
   const updateProvider = useUpdateProvider();
   const setProviderKey = useSetProviderKey();
+  const keyTestQuery = useProviderKeyTest(provider);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [keyError, setKeyError] = useState<string>();
+  const hasConfiguredKey = keyTestQuery.data?.status === "not_configured"
+    ? false
+    : provider.has_key || keyTestQuery.data !== undefined;
+  const keyStatus = resolveKeyStatus(
+    hasConfiguredKey,
+    keyTestQuery.isFetching,
+    keyTestQuery.data,
+    keyTestQuery.error,
+  );
 
   async function handleToggleEnabled(nextEnabled: boolean) {
     try {
@@ -30,6 +125,7 @@ export function ProviderCard({ provider }: ProviderCardProps) {
       setKeyError(undefined);
       await setProviderKey.mutateAsync({ id: provider.id, key });
       setIsDialogOpen(false);
+      void keyTestQuery.refetch();
     } catch (error) {
       if (error instanceof ApiError) {
         setKeyError(error.message);
@@ -38,6 +134,14 @@ export function ProviderCard({ provider }: ProviderCardProps) {
 
       setKeyError("Unable to save the API key right now.");
     }
+  }
+
+  function handleTestKey() {
+    if (!hasConfiguredKey) {
+      return;
+    }
+
+    void keyTestQuery.refetch();
   }
 
   return (
@@ -63,6 +167,28 @@ export function ProviderCard({ provider }: ProviderCardProps) {
               }}
             />
           </label>
+        </div>
+
+        <div className="mt-5 flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-gray-700">API key</span>
+              <span className={`rounded-md px-2.5 py-1 text-xs font-semibold ${KEY_STATUS_STYLES[keyStatus.tone]}`}>
+                {keyStatus.label}
+              </span>
+            </div>
+            <p className="text-sm text-gray-600">{keyStatus.message}</p>
+          </div>
+
+          <button
+            aria-label={`Test ${provider.name} API key`}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400"
+            disabled={!hasConfiguredKey || keyTestQuery.isFetching}
+            type="button"
+            onClick={handleTestKey}
+          >
+            {keyTestQuery.isFetching ? "Testing..." : "Test"}
+          </button>
         </div>
 
         <div className="mt-5 flex flex-wrap items-center gap-3">

--- a/frontend/src/features/providers/components/ProviderList.tsx
+++ b/frontend/src/features/providers/components/ProviderList.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ApiError } from "../../../lib/api-client.ts";
 import type { ProviderType } from "../../../types/api.ts";
-import { useProviders } from "../api/queries.ts";
+import { providerKeyTestQueryKey, testProviderKey, useProviders } from "../api/queries.ts";
 import { ProviderCard } from "./ProviderCard.tsx";
 
 interface ProviderListProps {
@@ -14,7 +16,9 @@ const TYPE_LABELS: Record<ProviderType, string> = {
 };
 
 export function ProviderList({ type }: ProviderListProps) {
+  const queryClient = useQueryClient();
   const providersQuery = useProviders(type);
+  const [isTestingAll, setIsTestingAll] = useState(false);
 
   if (providersQuery.isPending) {
     return (
@@ -48,11 +52,51 @@ export function ProviderList({ type }: ProviderListProps) {
     );
   }
 
+  const configuredProviders = providersQuery.data.filter((provider) => provider.has_key);
+
+  async function handleTestAll() {
+    if (configuredProviders.length === 0) {
+      return;
+    }
+
+    setIsTestingAll(true);
+    try {
+      await Promise.allSettled(
+        configuredProviders.map((provider) => (
+          queryClient.fetchQuery({
+            queryKey: providerKeyTestQueryKey(provider.id),
+            queryFn: () => testProviderKey(provider.id),
+          })
+        )),
+      );
+    } finally {
+      setIsTestingAll(false);
+    }
+  }
+
   return (
-    <div className="grid gap-4">
-      {providersQuery.data.map((provider) => (
-        <ProviderCard key={provider.id} provider={provider} />
-      ))}
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-gray-600">
+          {configuredProviders.length} of {providersQuery.data.length} providers have a saved API key.
+        </p>
+        <button
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400"
+          disabled={configuredProviders.length === 0 || isTestingAll}
+          type="button"
+          onClick={() => {
+            void handleTestAll();
+          }}
+        >
+          {isTestingAll ? "Testing..." : "Test All"}
+        </button>
+      </div>
+
+      <div className="grid gap-4">
+        {providersQuery.data.map((provider) => (
+          <ProviderCard key={provider.id} provider={provider} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/providers/components/ProvidersPage.test.tsx
+++ b/frontend/src/features/providers/components/ProvidersPage.test.tsx
@@ -2,16 +2,17 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Provider } from "../../../types/api.ts";
+import type { Provider, ProviderKeyTestResponse, ProviderType } from "../../../types/api.ts";
 import { ProvidersPage } from "./ProvidersPage.tsx";
 
-const providerState: Record<string, Provider[]> = {
+const baseProviderState: Record<ProviderType, Provider[]> = {
   tts: [
     {
       id: "google",
       name: "Google",
       type: "tts",
       enabled: true,
+      has_key: true,
       created_at: "2026-04-06T00:00:00.000Z",
     },
   ],
@@ -21,6 +22,7 @@ const providerState: Record<string, Provider[]> = {
       name: "OpenAI",
       type: "llm",
       enabled: true,
+      has_key: false,
       created_at: "2026-04-06T00:00:00.000Z",
     },
   ],
@@ -30,10 +32,15 @@ const providerState: Record<string, Provider[]> = {
       name: "OpenAI Realtime",
       type: "realtime",
       enabled: true,
+      has_key: true,
       created_at: "2026-04-06T00:00:00.000Z",
     },
   ],
 };
+
+let providerState: Record<ProviderType, Provider[]>;
+
+let validationState: Record<string, ProviderKeyTestResponse>;
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -69,6 +76,22 @@ describe("ProvidersPage", () => {
   const fetchMock = vi.fn<typeof fetch>();
 
   beforeEach(() => {
+    providerState = JSON.parse(JSON.stringify(baseProviderState)) as Record<ProviderType, Provider[]>;
+    validationState = {
+      google: {
+        provider_id: "google",
+        status: "valid",
+        message: "Saved API key is active.",
+        checked_at: "2026-04-06T00:00:00.000Z",
+      },
+      "openai-realtime": {
+        provider_id: "openai-realtime",
+        status: "valid",
+        message: "Saved API key is active.",
+        checked_at: "2026-04-06T00:00:00.000Z",
+      },
+    };
+
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
       const method = init?.method ?? "GET";
@@ -91,7 +114,22 @@ describe("ProvidersPage", () => {
       }
 
       if (method === "PUT" && url.endsWith("/providers/google/key")) {
+        providerState.tts[0] = { ...providerState.tts[0], has_key: true };
+        validationState.google = {
+          provider_id: "google",
+          status: "valid",
+          message: "Saved API key is active.",
+          checked_at: "2026-04-06T00:01:00.000Z",
+        };
         return noContentResponse();
+      }
+
+      if (method === "POST" && url.endsWith("/providers/google/key/test")) {
+        return jsonResponse(validationState.google);
+      }
+
+      if (method === "POST" && url.endsWith("/providers/openai-realtime/key/test")) {
+        return jsonResponse(validationState["openai-realtime"]);
       }
 
       return jsonResponse({ message: `Unhandled request: ${method} ${url}` }, 500);
@@ -103,28 +141,39 @@ describe("ProvidersPage", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fetchMock.mockReset();
-
-    providerState.tts[0] = { ...providerState.tts[0], enabled: true };
   });
 
-  it("loads TTS providers by default and switches to the LLM tab", async () => {
+  it("loads providers, validates saved keys, and skips providers without keys", async () => {
     const user = userEvent.setup();
 
     renderPage();
 
     expect(await screen.findByText("Google")).toBeInTheDocument();
+    expect(await screen.findByText("Active")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/providers/google/key/test",
+      expect.objectContaining({ method: "POST" }),
+    );
 
     await user.click(screen.getByRole("tab", { name: "LLM" }));
 
     expect(await screen.findByText("OpenAI")).toBeInTheDocument();
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Test OpenAI API key" })).toBeDisabled();
+    expect(screen.getByText("Add a key to test it.")).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/providers?type=llm",
       expect.objectContaining({ method: "GET" }),
     );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/providers/openai/key/test",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
-  it("updates provider enabled state and saves an API key", async () => {
+  it("updates provider enabled state, saves an API key, and validates it", async () => {
     const user = userEvent.setup();
+    providerState.tts[0] = { ...providerState.tts[0], has_key: false };
 
     renderPage();
 
@@ -143,6 +192,8 @@ describe("ProvidersPage", () => {
       );
     });
 
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+
     await user.click(screen.getByRole("button", { name: "Set API Key" }));
     await user.type(screen.getByLabelText("API key"), "sk-secret-123");
     await user.click(screen.getByRole("button", { name: "Save API Key" }));
@@ -154,6 +205,91 @@ describe("ProvidersPage", () => {
           method: "PUT",
           body: JSON.stringify({ key: "sk-secret-123" }),
         }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/providers/google/key/test",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(await screen.findByText("Active")).toBeInTheDocument();
+  });
+
+  it("manually tests a saved key and shows provider problems", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText("Active")).toBeInTheDocument();
+
+    validationState.google = {
+      provider_id: "google",
+      status: "invalid",
+      message: "The saved API key was rejected or lacks required access.",
+      checked_at: "2026-04-06T00:02:00.000Z",
+    };
+
+    await user.click(screen.getByRole("button", { name: "Test Google API key" }));
+
+    expect(await screen.findByText("Problem")).toBeInTheDocument();
+    expect(screen.getByText("The saved API key was rejected or lacks required access.")).toBeInTheDocument();
+  });
+
+  it("tests every configured provider in the active tab", async () => {
+    const user = userEvent.setup();
+    providerState.tts = [
+      ...providerState.tts,
+      {
+        id: "elevenlabs",
+        name: "ElevenLabs",
+        type: "tts",
+        enabled: true,
+        has_key: true,
+        created_at: "2026-04-06T00:00:00.000Z",
+      },
+    ];
+    validationState.elevenlabs = {
+      provider_id: "elevenlabs",
+      status: "valid",
+      message: "Saved API key is active.",
+      checked_at: "2026-04-06T00:03:00.000Z",
+    };
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (method === "GET" && url.endsWith("/providers?type=tts")) {
+        return jsonResponse(providerState.tts);
+      }
+
+      if (method === "POST" && url.endsWith("/providers/google/key/test")) {
+        return jsonResponse(validationState.google);
+      }
+
+      if (method === "POST" && url.endsWith("/providers/elevenlabs/key/test")) {
+        return jsonResponse(validationState.elevenlabs);
+      }
+
+      return jsonResponse({ message: `Unhandled request: ${method} ${url}` }, 500);
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("ElevenLabs")).toBeInTheDocument();
+    fetchMock.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "Test All" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/providers/google/key/test",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/providers/elevenlabs/key/test",
+        expect.objectContaining({ method: "POST" }),
       );
     });
   });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -10,7 +10,22 @@ export interface Provider {
   name: string;
   type: ProviderType;
   enabled: boolean;
+  has_key: boolean;
   created_at: string;
+}
+
+export type ProviderKeyTestStatus =
+  | 'valid'
+  | 'invalid'
+  | 'not_configured'
+  | 'unsupported'
+  | 'error';
+
+export interface ProviderKeyTestResponse {
+  provider_id: string;
+  status: ProviderKeyTestStatus;
+  message?: string;
+  checked_at: string;
 }
 
 // --- Dialog ---


### PR DESCRIPTION
## Summary
- Add safe `has_key` provider read field without decrypting or returning API keys.
- Add `POST /providers/:id/key/test` with sanitized validation statuses for TTS, LLM, and realtime providers.
- Update Providers UI with Not configured / Checking / Active / Problem / Unable to verify states, per-provider Test, Test All, and validation after saving a key.

## Verification
- `npm run build`
- `npm test`
- `npm run lint --workspace=frontend`
- Playwright UI check against Providers page

Closes #75