### PR TITLE
Fix Anthropic key validation

### DIFF
--- a/backend/src/providers/llm/anthropic.ts
+++ b/backend/src/providers/llm/anthropic.ts
@@ -55,11 +55,8 @@ export class AnthropicLLMProvider implements ILLMProvider {
 
   async validateCredentials(): Promise<boolean> {
     try {
-      await this.client.messages.create({
-        model: 'claude-haiku-3-5-20241022',
-        max_tokens: 1,
-        messages: [{ role: 'user', content: 'hi' }],
-      });
+      const iterator = this.client.models.list({ limit: 1 })[Symbol.asyncIterator]();
+      await iterator.next();
       return true;
     } catch {
       return false;

--- a/backend/tests/providers/anthropic-llm.test.ts
+++ b/backend/tests/providers/anthropic-llm.test.ts
@@ -3,6 +3,7 @@ import Anthropic from '@anthropic-ai/sdk';
 
 // Mock the Anthropic SDK -- vi.mock is hoisted before imports
 const mockCreate = vi.fn();
+const mockModelsList = vi.fn();
 vi.mock('@anthropic-ai/sdk', () => ({
   default: vi.fn(),
 }));
@@ -12,8 +13,9 @@ describe('AnthropicLLMProvider', () => {
 
   beforeEach(() => {
     mockCreate.mockReset();
+    mockModelsList.mockReset();
     vi.mocked(Anthropic).mockImplementation(
-      () => ({ messages: { create: mockCreate } }) as unknown as Anthropic,
+      () => ({ messages: { create: mockCreate }, models: { list: mockModelsList } }) as unknown as Anthropic,
     );
     provider = new AnthropicLLMProvider('test-api-key');
   });
@@ -214,18 +216,30 @@ describe('AnthropicLLMProvider', () => {
   });
 
   describe('validateCredentials', () => {
-    it('returns true when API call succeeds', async () => {
-      mockCreate.mockResolvedValue({
-        content: [{ type: 'text', text: 'hi' }],
-      });
+    function mockModelIterator(result: unknown): AsyncIterable<unknown> {
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield result;
+        },
+      };
+    }
+
+    it('returns true when model listing succeeds', async () => {
+      mockModelsList.mockReturnValue(mockModelIterator({
+        id: 'claude-3-5-haiku-20241022',
+      }));
 
       const result = await provider.validateCredentials();
 
       expect(result).toBe(true);
+      expect(mockModelsList).toHaveBeenCalledWith({ limit: 1 });
+      expect(mockCreate).not.toHaveBeenCalled();
     });
 
-    it('returns false when API call throws', async () => {
-      mockCreate.mockRejectedValue(new Error('authentication_error'));
+    it('returns false when model listing throws', async () => {
+      mockModelsList.mockImplementation(() => {
+        throw new Error('authentication_error');
+      });
 
       const result = await provider.validateCredentials();
 


### PR DESCRIPTION
## Summary
- Change Anthropic API key validation to use the Models API instead of creating a message
- Keep validation focused on authentication so low billing credits do not mark a valid key as rejected
- Update Anthropic provider tests to assert that validation does not call `messages.create`

## Testing
- `npx vitest run tests/providers/anthropic-llm.test.ts tests/providers/llm-registry.test.ts tests/routes/providers.test.ts`
- `npx tsc --noEmit`
- Browser verification on `/providers`: Anthropic key test returns `status: "valid"` and the UI shows `Active`

Closes #79
