### PR TITLE
Fix realtime microphone audio decoding failures

### DIFF
--- a/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
+++ b/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
@@ -38,7 +38,7 @@ export function RealtimeProviderTab({
 
   useEffect(() => {
     if (!session.isConnected && isRecording) {
-      stopMicrophone();
+      void stopMicrophone();
     }
   }, [isRecording, session.isConnected, stopMicrophone]);
 
@@ -69,7 +69,7 @@ export function RealtimeProviderTab({
   }
 
   async function handleStop() {
-    stopMicrophone();
+    await stopMicrophone();
     await session.disconnect();
   }
 

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -13,27 +13,41 @@ interface FakeWorkletMessage {
 
 class FakeAudioWorkletPort {
   onmessage: ((event: FakeWorkletMessage) => void) | null = null;
+  deferFlush = false;
   flushSamples = new Float32Array(0);
   postMessage = vi.fn((message: { type?: string }) => {
     if (message.type === "flush") {
-      this.onmessage?.({
-        data: {
-          sampleRate: 16_000,
-          samples: this.flushSamples,
-          type: "flushed",
-        },
-      });
+      if (this.deferFlush) {
+        return;
+      }
+
+      this.flush();
     }
   });
+
+  flush() {
+    this.onmessage?.({
+      data: {
+        sampleRate: 16_000,
+        samples: this.flushSamples,
+        type: "flushed",
+      },
+    });
+  }
 }
 
 class FakeAudioWorkletNode {
   static instance: FakeAudioWorkletNode | null = null;
+  static shouldThrow = false;
 
   readonly port = new FakeAudioWorkletPort();
   disconnect = vi.fn();
 
   constructor() {
+    if (FakeAudioWorkletNode.shouldThrow) {
+      throw new Error("Unable to create worklet node");
+    }
+
     FakeAudioWorkletNode.instance = this;
   }
 }
@@ -70,6 +84,16 @@ function TestHarness({ onChunk }: { onChunk: (chunk: Uint8Array) => void }) {
   );
 }
 
+function HookProbe({
+  onRender,
+}: {
+  onRender: (microphone: ReturnType<typeof useMicrophone>) => void;
+}) {
+  const microphone = useMicrophone();
+  onRender(microphone);
+  return null;
+}
+
 describe("useMicrophone", () => {
   const getUserMedia = vi.fn<() => Promise<MediaStream>>();
   const trackStop = vi.fn();
@@ -79,6 +103,7 @@ describe("useMicrophone", () => {
 
   beforeEach(() => {
     FakeAudioWorkletNode.instance = null;
+    FakeAudioWorkletNode.shouldThrow = false;
     sourceNode = new FakeMediaStreamSourceNode();
     addModule.mockResolvedValue(undefined);
 
@@ -169,6 +194,54 @@ describe("useMicrophone", () => {
     expect(onChunk.mock.calls[0]?.[0]).toBeInstanceOf(Uint8Array);
     expect(onChunk.mock.calls[0]?.[0]).toHaveLength(4);
     expect(workletNode!.disconnect).toHaveBeenCalled();
+    expect(sourceNode.disconnect).toHaveBeenCalled();
+    expect(trackStop).toHaveBeenCalled();
+  });
+
+  it("returns the same in-flight stop promise for concurrent stop calls", async () => {
+    let microphone: ReturnType<typeof useMicrophone> | null = null;
+
+    render(<HookProbe onRender={(nextMicrophone) => {
+      microphone = nextMicrophone;
+    }} />);
+
+    await act(async () => {
+      await microphone!.start({ onChunk: vi.fn() });
+    });
+
+    const workletNode = FakeAudioWorkletNode.instance;
+    expect(workletNode).not.toBeNull();
+    workletNode!.port.deferFlush = true;
+
+    const firstStop = microphone!.stop();
+    const secondStop = microphone!.stop();
+
+    expect(secondStop).toBe(firstStop);
+    expect(workletNode!.port.postMessage).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      workletNode!.port.flush();
+    });
+
+    await firstStop;
+    await secondStop;
+    expect(workletNode!.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the acquired stream if worklet node creation fails", async () => {
+    let microphone: ReturnType<typeof useMicrophone> | null = null;
+    FakeAudioWorkletNode.shouldThrow = true;
+
+    render(<HookProbe onRender={(nextMicrophone) => {
+      microphone = nextMicrophone;
+    }} />);
+
+    await expect(
+      act(async () => {
+        await microphone!.start({ onChunk: vi.fn() });
+      }),
+    ).rejects.toThrow("Unable to create worklet node");
+
     expect(sourceNode.disconnect).toHaveBeenCalled();
     expect(trackStop).toHaveBeenCalled();
   });

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -7,11 +7,24 @@ interface FakeWorkletMessage {
   data: {
     sampleRate: number;
     samples: Float32Array;
+    type?: string;
   };
 }
 
 class FakeAudioWorkletPort {
   onmessage: ((event: FakeWorkletMessage) => void) | null = null;
+  flushSamples = new Float32Array(0);
+  postMessage = vi.fn((message: { type?: string }) => {
+    if (message.type === "flush") {
+      this.onmessage?.({
+        data: {
+          sampleRate: 16_000,
+          samples: this.flushSamples,
+          type: "flushed",
+        },
+      });
+    }
+  });
 }
 
 class FakeAudioWorkletNode {
@@ -43,7 +56,12 @@ function TestHarness({ onChunk }: { onChunk: (chunk: Uint8Array) => void }) {
       >
         Start
       </button>
-      <button type="button" onClick={microphone.stop}>
+      <button
+        type="button"
+        onClick={() => {
+          void microphone.stop();
+        }}
+      >
         Stop
       </button>
       <span data-testid="chunk-count">{microphone.chunks.length}</span>
@@ -115,6 +133,7 @@ describe("useMicrophone", () => {
         data: {
           sampleRate: 16_000,
           samples: new Float32Array([0, 0.5, -0.5]),
+          type: "chunk",
         },
       });
     });
@@ -126,5 +145,31 @@ describe("useMicrophone", () => {
     expect(screen.getByTestId("chunk-count")).toHaveTextContent("1");
     expect(sourceNode.connect).toHaveBeenCalledWith(FakeAudioWorkletNode.instance);
     expect(decodeAudioData).not.toHaveBeenCalled();
+  });
+
+  it("flushes trailing worklet samples before stopping capture", async () => {
+    const user = userEvent.setup();
+    const onChunk =
+      vi.fn<(chunk: Uint8Array) => Promise<void>>().mockResolvedValue(undefined);
+
+    render(<TestHarness onChunk={onChunk} />);
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(addModule).toHaveBeenCalled());
+
+    const workletNode = FakeAudioWorkletNode.instance;
+    expect(workletNode).not.toBeNull();
+    workletNode!.port.flushSamples = new Float32Array([0.25, -0.25]);
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => expect(onChunk).toHaveBeenCalledTimes(1));
+
+    expect(workletNode!.port.postMessage).toHaveBeenCalledWith({ type: "flush" });
+    expect(onChunk.mock.calls[0]?.[0]).toBeInstanceOf(Uint8Array);
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(4);
+    expect(workletNode!.disconnect).toHaveBeenCalled();
+    expect(sourceNode.disconnect).toHaveBeenCalled();
+    expect(trackStop).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -1,0 +1,130 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useMicrophone } from "./useMicrophone.ts";
+
+interface FakeWorkletMessage {
+  data: {
+    sampleRate: number;
+    samples: Float32Array;
+  };
+}
+
+class FakeAudioWorkletPort {
+  onmessage: ((event: FakeWorkletMessage) => void) | null = null;
+}
+
+class FakeAudioWorkletNode {
+  static instance: FakeAudioWorkletNode | null = null;
+
+  readonly port = new FakeAudioWorkletPort();
+  disconnect = vi.fn();
+
+  constructor() {
+    FakeAudioWorkletNode.instance = this;
+  }
+}
+
+class FakeMediaStreamSourceNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+function TestHarness({ onChunk }: { onChunk: (chunk: Uint8Array) => void }) {
+  const microphone = useMicrophone();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          void microphone.start({ onChunk });
+        }}
+      >
+        Start
+      </button>
+      <button type="button" onClick={microphone.stop}>
+        Stop
+      </button>
+      <span data-testid="chunk-count">{microphone.chunks.length}</span>
+      {microphone.error ? <span role="alert">{microphone.error}</span> : null}
+    </div>
+  );
+}
+
+describe("useMicrophone", () => {
+  const getUserMedia = vi.fn<() => Promise<MediaStream>>();
+  const trackStop = vi.fn();
+  const addModule = vi.fn();
+  const decodeAudioData = vi.fn();
+  let sourceNode: FakeMediaStreamSourceNode;
+
+  beforeEach(() => {
+    FakeAudioWorkletNode.instance = null;
+    sourceNode = new FakeMediaStreamSourceNode();
+    addModule.mockResolvedValue(undefined);
+
+    getUserMedia.mockResolvedValue({
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream);
+
+    class FakeAudioContext {
+      readonly audioWorklet = { addModule };
+      readonly destination = {};
+      readonly sampleRate = 48_000;
+      readonly state = "running";
+      close = vi.fn();
+      decodeAudioData = decodeAudioData;
+      resume = vi.fn();
+
+      createMediaStreamSource() {
+        return sourceNode;
+      }
+    }
+
+    vi.stubGlobal("AudioContext", FakeAudioContext);
+    vi.stubGlobal("AudioWorkletNode", FakeAudioWorkletNode);
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:realtime-microphone-worklet"),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("streams PCM chunks from Web Audio without decoding MediaRecorder blobs", async () => {
+    const user = userEvent.setup();
+    const onChunk = vi.fn();
+
+    render(<TestHarness onChunk={onChunk} />);
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledWith({ audio: true }));
+    await waitFor(() => expect(addModule).toHaveBeenCalled());
+
+    act(() => {
+      FakeAudioWorkletNode.instance?.port.onmessage?.({
+        data: {
+          sampleRate: 16_000,
+          samples: new Float32Array([0, 0.5, -0.5]),
+        },
+      });
+    });
+
+    await waitFor(() => expect(onChunk).toHaveBeenCalledTimes(1));
+
+    expect(onChunk.mock.calls[0]?.[0]).toBeInstanceOf(Uint8Array);
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(6);
+    expect(screen.getByTestId("chunk-count")).toHaveTextContent("1");
+    expect(sourceNode.connect).toHaveBeenCalledWith(FakeAudioWorkletNode.instance);
+    expect(decodeAudioData).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -8,6 +8,25 @@ class RealtimeMicrophoneProcessor extends AudioWorkletProcessor {
     super();
     this.buffer = new Float32Array(4096);
     this.offset = 0;
+    this.port.onmessage = (event) => {
+      if (event.data?.type === "flush") {
+        this.flush();
+      }
+    };
+  }
+
+  flush() {
+    const samples = this.offset > 0
+      ? this.buffer.slice(0, this.offset)
+      : new Float32Array(0);
+
+    this.port.postMessage(
+      { type: "flushed", sampleRate, samples },
+      [samples.buffer],
+    );
+
+    this.buffer = new Float32Array(4096);
+    this.offset = 0;
   }
 
   process(inputs) {
@@ -28,7 +47,10 @@ class RealtimeMicrophoneProcessor extends AudioWorkletProcessor {
 
       if (this.offset === this.buffer.length) {
         const samples = this.buffer;
-        this.port.postMessage({ sampleRate, samples }, [samples.buffer]);
+        this.port.postMessage(
+          { type: "chunk", sampleRate, samples },
+          [samples.buffer],
+        );
         this.buffer = new Float32Array(4096);
         this.offset = 0;
       }
@@ -52,7 +74,7 @@ interface UseMicrophoneResult {
   error: string | null;
   isRecording: boolean;
   start: (options?: UseMicrophoneStartOptions) => Promise<void>;
-  stop: () => void;
+  stop: () => Promise<void>;
 }
 
 type AudioContextConstructor = new (options?: AudioContextOptions) => AudioContext;
@@ -144,18 +166,14 @@ export function useMicrophone(): UseMicrophoneResult {
   const streamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const chunkHandlerRef = useRef<UseMicrophoneStartOptions["onChunk"]>(undefined);
+  const flushResolverRef = useRef<(() => void) | null>(null);
+  const pendingChunkSendsRef = useRef<Promise<void>>(Promise.resolve());
 
   const [chunks, setChunks] = useState<Uint8Array[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isRecording, setIsRecording] = useState(false);
 
-  const stop = useCallback(() => {
-    if (workletNodeRef.current) {
-      workletNodeRef.current.port.onmessage = null;
-      workletNodeRef.current.disconnect();
-      workletNodeRef.current = null;
-    }
-
+  const stop = useCallback(async () => {
     if (sourceNodeRef.current) {
       sourceNodeRef.current.disconnect();
       sourceNodeRef.current = null;
@@ -166,6 +184,26 @@ export function useMicrophone(): UseMicrophoneResult {
         track.stop();
       }
       streamRef.current = null;
+    }
+
+    const workletNode = workletNodeRef.current;
+    if (workletNode) {
+      await new Promise<void>((resolve) => {
+        flushResolverRef.current = () => {
+          resolve();
+        };
+
+        try {
+          workletNode.port.postMessage({ type: "flush" });
+        } catch {
+          flushResolverRef.current = null;
+          resolve();
+        }
+      });
+
+      workletNode.port.onmessage = null;
+      workletNode.disconnect();
+      workletNodeRef.current = null;
     }
 
     chunkHandlerRef.current = undefined;
@@ -187,7 +225,7 @@ export function useMicrophone(): UseMicrophoneResult {
       throw new Error("Audio processing is not supported in this browser.");
     }
 
-    stop();
+    await stop();
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
 
@@ -237,8 +275,13 @@ export function useMicrophone(): UseMicrophoneResult {
     workletNode.port.onmessage = (event: MessageEvent<{
       sampleRate?: number;
       samples?: Float32Array;
+      type?: string;
     }>) => {
       if (!workletNodeRef.current || !(event.data.samples instanceof Float32Array)) {
+        if (event.data.type === "flushed") {
+          flushResolverRef.current?.();
+          flushResolverRef.current = null;
+        }
         return;
       }
 
@@ -249,23 +292,31 @@ export function useMicrophone(): UseMicrophoneResult {
       );
       const pcmChunk = floatToPcm16(resampled);
 
-      if (pcmChunk.byteLength === 0) {
-        return;
-      }
+      pendingChunkSendsRef.current = pendingChunkSendsRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          if (pcmChunk.byteLength === 0) {
+            return;
+          }
 
-      setChunks((currentChunks) => [...currentChunks, pcmChunk]);
-
-      void (async () => {
-        try {
+          setChunks((currentChunks) => [...currentChunks, pcmChunk]);
           await chunkHandlerRef.current?.(pcmChunk);
-        } catch (processingError) {
+        })
+        .catch((processingError) => {
           const message =
             processingError instanceof Error
               ? processingError.message
               : "Unable to process microphone audio.";
           setError(message);
-        }
-      })();
+        })
+        .finally(() => {
+          if (event.data.type === "flushed") {
+            flushResolverRef.current?.();
+            flushResolverRef.current = null;
+          }
+        });
+
+      void pendingChunkSendsRef.current;
     };
 
     sourceNode.connect(workletNode);
@@ -273,7 +324,7 @@ export function useMicrophone(): UseMicrophoneResult {
 
   useEffect(() => {
     return () => {
-      stop();
+      void stop();
 
       if (audioContextRef.current) {
         void audioContextRef.current.close();

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -168,46 +168,68 @@ export function useMicrophone(): UseMicrophoneResult {
   const chunkHandlerRef = useRef<UseMicrophoneStartOptions["onChunk"]>(undefined);
   const flushResolverRef = useRef<(() => void) | null>(null);
   const pendingChunkSendsRef = useRef<Promise<void>>(Promise.resolve());
+  const stopPromiseRef = useRef<Promise<void> | null>(null);
 
   const [chunks, setChunks] = useState<Uint8Array[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isRecording, setIsRecording] = useState(false);
 
-  const stop = useCallback(async () => {
-    if (sourceNodeRef.current) {
-      sourceNodeRef.current.disconnect();
-      sourceNodeRef.current = null;
+  const stop = useCallback((): Promise<void> => {
+    if (stopPromiseRef.current) {
+      return stopPromiseRef.current;
     }
 
-    if (streamRef.current) {
-      for (const track of streamRef.current.getTracks()) {
-        track.stop();
+    const stopPromise = (async () => {
+      if (sourceNodeRef.current) {
+        sourceNodeRef.current.disconnect();
+        sourceNodeRef.current = null;
       }
-      streamRef.current = null;
-    }
 
-    const workletNode = workletNodeRef.current;
-    if (workletNode) {
-      await new Promise<void>((resolve) => {
-        flushResolverRef.current = () => {
-          resolve();
-        };
-
-        try {
-          workletNode.port.postMessage({ type: "flush" });
-        } catch {
-          flushResolverRef.current = null;
-          resolve();
+      if (streamRef.current) {
+        for (const track of streamRef.current.getTracks()) {
+          track.stop();
         }
-      });
+        streamRef.current = null;
+      }
 
-      workletNode.port.onmessage = null;
-      workletNode.disconnect();
-      workletNodeRef.current = null;
-    }
+      const workletNode = workletNodeRef.current;
+      if (workletNode) {
+        await new Promise<void>((resolve) => {
+          let isSettled = false;
+          const timeoutId = window.setTimeout(finish, 500);
+          function finish() {
+            if (isSettled) {
+              return;
+            }
 
-    chunkHandlerRef.current = undefined;
-    setIsRecording(false);
+            isSettled = true;
+            window.clearTimeout(timeoutId);
+            flushResolverRef.current = null;
+            resolve();
+          }
+
+          flushResolverRef.current = finish;
+
+          try {
+            workletNode.port.postMessage({ type: "flush" });
+          } catch {
+            finish();
+          }
+        });
+
+        workletNode.port.onmessage = null;
+        workletNode.disconnect();
+        workletNodeRef.current = null;
+      }
+
+      chunkHandlerRef.current = undefined;
+      setIsRecording(false);
+    })().finally(() => {
+      stopPromiseRef.current = null;
+    });
+
+    stopPromiseRef.current = stopPromise;
+    return stopPromise;
   }, []);
 
   const start = useCallback(async (options: UseMicrophoneStartOptions = {}) => {
@@ -253,15 +275,31 @@ export function useMicrophone(): UseMicrophoneResult {
       throw new Error(message);
     }
 
-    const sourceNode = audioContext.createMediaStreamSource(stream);
-    const workletNode = new AudioWorkletNode(
-      audioContext,
-      MICROPHONE_WORKLET_NAME,
-      {
-        numberOfInputs: 1,
-        numberOfOutputs: 0,
-      },
-    );
+    let sourceNode: MediaStreamAudioSourceNode | null = null;
+    let workletNode: AudioWorkletNode | null = null;
+    try {
+      sourceNode = audioContext.createMediaStreamSource(stream);
+      workletNode = new AudioWorkletNode(
+        audioContext,
+        MICROPHONE_WORKLET_NAME,
+        {
+          numberOfInputs: 1,
+          numberOfOutputs: 0,
+        },
+      );
+    } catch (nodeError) {
+      sourceNode?.disconnect();
+      for (const track of stream.getTracks()) {
+        track.stop();
+      }
+
+      const message =
+        nodeError instanceof Error
+          ? nodeError.message
+          : "Unable to initialize microphone audio processing.";
+      setError(message);
+      throw new Error(message);
+    }
 
     chunkHandlerRef.current = options.onChunk;
     streamRef.current = stream;
@@ -324,12 +362,12 @@ export function useMicrophone(): UseMicrophoneResult {
 
   useEffect(() => {
     return () => {
-      void stop();
-
-      if (audioContextRef.current) {
-        void audioContextRef.current.close();
-        audioContextRef.current = null;
-      }
+      void stop().finally(() => {
+        if (audioContextRef.current) {
+          void audioContextRef.current.close();
+          audioContextRef.current = null;
+        }
+      });
     };
   }, [stop]);
 

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -1,11 +1,50 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const TARGET_SAMPLE_RATE = 16_000;
+const MICROPHONE_WORKLET_NAME = "realtime-microphone-processor";
+const MICROPHONE_WORKLET_SOURCE = `
+class RealtimeMicrophoneProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buffer = new Float32Array(4096);
+    this.offset = 0;
+  }
+
+  process(inputs) {
+    const channels = inputs[0];
+    if (!channels || channels.length === 0 || channels[0].length === 0) {
+      return true;
+    }
+
+    const frameCount = channels[0].length;
+    for (let frame = 0; frame < frameCount; frame += 1) {
+      let sample = 0;
+      for (let channel = 0; channel < channels.length; channel += 1) {
+        sample += channels[channel][frame] / channels.length;
+      }
+
+      this.buffer[this.offset] = sample;
+      this.offset += 1;
+
+      if (this.offset === this.buffer.length) {
+        const samples = this.buffer;
+        this.port.postMessage({ sampleRate, samples }, [samples.buffer]);
+        this.buffer = new Float32Array(4096);
+        this.offset = 0;
+      }
+    }
+
+    return true;
+  }
+}
+
+registerProcessor("${MICROPHONE_WORKLET_NAME}", RealtimeMicrophoneProcessor);
+`;
+
+const loadedAudioWorklets = new WeakSet<AudioContext>();
 
 export interface UseMicrophoneStartOptions {
-  mimeType?: string;
   onChunk?: (chunk: Uint8Array) => void | Promise<void>;
-  timeSliceMs?: number;
 }
 
 interface UseMicrophoneResult {
@@ -16,58 +55,16 @@ interface UseMicrophoneResult {
   stop: () => void;
 }
 
-type RecorderWithMimeSupport = typeof MediaRecorder & {
-  isTypeSupported?: (mimeType: string) => boolean;
-};
+type AudioContextConstructor = new (options?: AudioContextOptions) => AudioContext;
 
-function getAudioContextConstructor():
-  | (new () => AudioContext)
-  | undefined {
+function getAudioContextConstructor(): AudioContextConstructor | undefined {
   if (typeof window === "undefined") {
     return undefined;
   }
 
   return window.AudioContext ?? (window as typeof window & {
-    webkitAudioContext?: new () => AudioContext;
+    webkitAudioContext?: AudioContextConstructor;
   }).webkitAudioContext;
-}
-
-function chooseRecorderMimeType(preferred?: string): string | undefined {
-  if (typeof MediaRecorder === "undefined") {
-    return undefined;
-  }
-
-  const recorder = MediaRecorder as RecorderWithMimeSupport;
-  const supported = recorder.isTypeSupported?.bind(recorder);
-
-  const candidates = [
-    preferred,
-    "audio/webm;codecs=opus",
-    "audio/webm",
-    "audio/ogg;codecs=opus",
-  ].filter((value): value is string => Boolean(value));
-
-  if (!supported) {
-    return candidates[0];
-  }
-
-  return candidates.find((mimeType) => supported(mimeType));
-}
-
-function mixToMono(audioBuffer: AudioBuffer): Float32Array {
-  if (audioBuffer.numberOfChannels === 1) {
-    return audioBuffer.getChannelData(0);
-  }
-
-  const mono = new Float32Array(audioBuffer.length);
-  for (let channel = 0; channel < audioBuffer.numberOfChannels; channel += 1) {
-    const channelData = audioBuffer.getChannelData(channel);
-    for (let index = 0; index < channelData.length; index += 1) {
-      mono[index] += channelData[index] / audioBuffer.numberOfChannels;
-    }
-  }
-
-  return mono;
 }
 
 function downsampleBuffer(
@@ -120,24 +117,30 @@ function floatToPcm16(input: Float32Array): Uint8Array {
   return new Uint8Array(view.buffer);
 }
 
-async function convertBlobToPcm16(
-  blob: Blob,
-  audioContext: AudioContext,
-): Promise<Uint8Array> {
-  const sourceBuffer = await blob.arrayBuffer();
-  const decodedBuffer = await audioContext.decodeAudioData(sourceBuffer.slice(0));
-  const mono = mixToMono(decodedBuffer);
-  const resampled = downsampleBuffer(
-    mono,
-    decodedBuffer.sampleRate,
-    TARGET_SAMPLE_RATE,
+async function loadMicrophoneWorklet(audioContext: AudioContext): Promise<void> {
+  if (loadedAudioWorklets.has(audioContext)) {
+    return;
+  }
+
+  if (!audioContext.audioWorklet) {
+    throw new Error("AudioWorklet microphone processing is not supported in this browser.");
+  }
+
+  const moduleUrl = URL.createObjectURL(
+    new Blob([MICROPHONE_WORKLET_SOURCE], { type: "text/javascript" }),
   );
 
-  return floatToPcm16(resampled);
+  try {
+    await audioContext.audioWorklet.addModule(moduleUrl);
+    loadedAudioWorklets.add(audioContext);
+  } finally {
+    URL.revokeObjectURL(moduleUrl);
+  }
 }
 
 export function useMicrophone(): UseMicrophoneResult {
-  const recorderRef = useRef<MediaRecorder | null>(null);
+  const workletNodeRef = useRef<AudioWorkletNode | null>(null);
+  const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const chunkHandlerRef = useRef<UseMicrophoneStartOptions["onChunk"]>(undefined);
@@ -147,11 +150,15 @@ export function useMicrophone(): UseMicrophoneResult {
   const [isRecording, setIsRecording] = useState(false);
 
   const stop = useCallback(() => {
-    const recorder = recorderRef.current;
-    recorderRef.current = null;
+    if (workletNodeRef.current) {
+      workletNodeRef.current.port.onmessage = null;
+      workletNodeRef.current.disconnect();
+      workletNodeRef.current = null;
+    }
 
-    if (recorder && recorder.state !== "inactive") {
-      recorder.stop();
+    if (sourceNodeRef.current) {
+      sourceNodeRef.current.disconnect();
+      sourceNodeRef.current = null;
     }
 
     if (streamRef.current) {
@@ -161,14 +168,14 @@ export function useMicrophone(): UseMicrophoneResult {
       streamRef.current = null;
     }
 
+    chunkHandlerRef.current = undefined;
     setIsRecording(false);
   }, []);
 
   const start = useCallback(async (options: UseMicrophoneStartOptions = {}) => {
     if (
       typeof navigator === "undefined" ||
-      !navigator.mediaDevices?.getUserMedia ||
-      typeof MediaRecorder === "undefined"
+      !navigator.mediaDevices?.getUserMedia
     ) {
       setError("Microphone capture is not supported in this browser.");
       throw new Error("Microphone capture is not supported in this browser.");
@@ -183,36 +190,73 @@ export function useMicrophone(): UseMicrophoneResult {
     stop();
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    const mimeType = chooseRecorderMimeType(options.mimeType);
-    const recorder = mimeType
-      ? new MediaRecorder(stream, { mimeType })
-      : new MediaRecorder(stream);
 
     if (!audioContextRef.current) {
       audioContextRef.current = new AudioContextCtor();
     }
 
+    if (audioContextRef.current.state === "suspended") {
+      await audioContextRef.current.resume();
+    }
+
+    const audioContext = audioContextRef.current;
+    try {
+      await loadMicrophoneWorklet(audioContext);
+    } catch (workletError) {
+      for (const track of stream.getTracks()) {
+        track.stop();
+      }
+
+      const message =
+        workletError instanceof Error
+          ? workletError.message
+          : "Unable to initialize microphone audio processing.";
+      setError(message);
+      throw new Error(message);
+    }
+
+    const sourceNode = audioContext.createMediaStreamSource(stream);
+    const workletNode = new AudioWorkletNode(
+      audioContext,
+      MICROPHONE_WORKLET_NAME,
+      {
+        numberOfInputs: 1,
+        numberOfOutputs: 0,
+      },
+    );
+
     chunkHandlerRef.current = options.onChunk;
     streamRef.current = stream;
-    recorderRef.current = recorder;
+    sourceNodeRef.current = sourceNode;
+    workletNodeRef.current = workletNode;
 
     setChunks([]);
     setError(null);
     setIsRecording(true);
 
-    recorder.ondataavailable = (event) => {
-      if (event.data.size === 0 || !audioContextRef.current) {
+    workletNode.port.onmessage = (event: MessageEvent<{
+      sampleRate?: number;
+      samples?: Float32Array;
+    }>) => {
+      if (!workletNodeRef.current || !(event.data.samples instanceof Float32Array)) {
         return;
       }
 
+      const resampled = downsampleBuffer(
+        event.data.samples,
+        event.data.sampleRate ?? audioContext.sampleRate,
+        TARGET_SAMPLE_RATE,
+      );
+      const pcmChunk = floatToPcm16(resampled);
+
+      if (pcmChunk.byteLength === 0) {
+        return;
+      }
+
+      setChunks((currentChunks) => [...currentChunks, pcmChunk]);
+
       void (async () => {
         try {
-          const pcmChunk = await convertBlobToPcm16(
-            event.data,
-            audioContextRef.current!,
-          );
-
-          setChunks((currentChunks) => [...currentChunks, pcmChunk]);
           await chunkHandlerRef.current?.(pcmChunk);
         } catch (processingError) {
           const message =
@@ -224,24 +268,7 @@ export function useMicrophone(): UseMicrophoneResult {
       })();
     };
 
-    recorder.onerror = () => {
-      setError("Microphone recording failed.");
-      stop();
-    };
-
-    recorder.onstop = () => {
-      if (streamRef.current) {
-        for (const track of streamRef.current.getTracks()) {
-          track.stop();
-        }
-        streamRef.current = null;
-      }
-
-      recorderRef.current = null;
-      setIsRecording(false);
-    };
-
-    recorder.start(options.timeSliceMs ?? 400);
+    sourceNode.connect(workletNode);
   }, [stop]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- replace the realtime microphone `MediaRecorder`/`decodeAudioData` path with an `AudioWorkletNode` pipeline
- stream mono PCM16 chunks at 16 kHz directly to the realtime websocket sender
- add a regression test proving microphone chunks are emitted without calling `decodeAudioData`

## Verification
- `npm run test --workspace=frontend -- src/features/realtime/hooks/useMicrophone.test.tsx`
- `npm run lint --workspace=frontend`
- `npm run build --workspace=frontend`
- Real UI session starts reached `Connected` for OpenAI, Gemini, and ElevenLabs with no `Unable to decode audio data`, no request failures, and no relevant browser console errors/warnings.

Closes #81