### PR TITLE
fix(inworld): correct models API endpoint and response parsing

### DIFF
--- a/backend/src/providers/realtime/inworld.ts
+++ b/backend/src/providers/realtime/inworld.ts
@@ -8,7 +8,7 @@ import type {
 } from './types.js';
 
 const INWORLD_BASE_URL = 'https://api.inworld.ai';
-const INWORLD_MODELS_URL = `${INWORLD_BASE_URL}/v1/models`;
+const INWORLD_MODELS_URL = `${INWORLD_BASE_URL}/llm/v1alpha/models`;
 const INWORLD_REALTIME_URL = 'wss://api.inworld.ai/api/v1/realtime/session';
 const DEFAULT_REALTIME_MODEL = 'google-ai-studio/gemini-2.5-flash';
 const DEFAULT_VOICE = 'Dennis';
@@ -268,14 +268,14 @@ export class InworldRealtimeProvider implements IRealtimeProvider {
     }
 
     const models = new Set<string>();
-    const items = Array.isArray(body.data) ? body.data : [];
+    const items = Array.isArray(body.models) ? body.models : [];
 
     for (const item of items) {
-      if (!isRecord(item) || typeof item.id !== 'string' || !item.id) {
+      if (!isRecord(item) || typeof item.model !== 'string' || !item.model) {
         continue;
       }
 
-      models.add(item.id);
+      models.add(item.model);
     }
 
     return models.size > 0 ? [...models].sort() : [DEFAULT_REALTIME_MODEL];

--- a/backend/tests/providers/inworld-realtime.test.ts
+++ b/backend/tests/providers/inworld-realtime.test.ts
@@ -121,13 +121,13 @@ describe('InworldRealtimeProvider', () => {
     expect(provider.name).toBe('Inworld Realtime');
   });
 
-  it('lists available Inworld models from the OpenAI-compatible models endpoint', async () => {
+  it('lists available Inworld models from the Inworld models endpoint', async () => {
     mockFetch.mockResolvedValueOnce(createJsonResponse({
-      data: [
-        { id: 'openai/gpt-4.1-nano' },
-        { id: 'google-ai-studio/gemini-2.5-flash' },
-        { id: 'openai/gpt-4.1-nano' },
-        { id: 123 },
+      models: [
+        { model: 'openai/gpt-4.1-nano' },
+        { model: 'google-ai-studio/gemini-2.5-flash' },
+        { model: 'openai/gpt-4.1-nano' },
+        { model: 123 },
         {},
       ],
     }));
@@ -138,7 +138,7 @@ describe('InworldRealtimeProvider', () => {
     ]);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.inworld.ai/v1/models',
+      'https://api.inworld.ai/llm/v1alpha/models',
       {
         headers: {
           Authorization: 'Basic test-api-key',


### PR DESCRIPTION
Fixes #82

## Summary

- Corrects the Inworld models API URL from `/v1/models` to `/llm/v1alpha/models`
- Fixes response parsing: `body.data[].id` → `body.models[].model` to match the actual Inworld API response shape

## Root cause

The code assumed an OpenAI-compatible models endpoint at `/v1/models`, but Inworld's actual REST API is at `/llm/v1alpha/models` and returns a different JSON structure (`models` array with a `model` field per item).

## Test plan

- [x] Updated unit test asserts the correct URL and response shape
- [x] All 434 backend tests pass
- [x] `GET /realtime/inworld-realtime/models` returns HTTP 200 with a populated model list

🤖 Generated with [Claude Code](https://claude.com/claude-code)