### PR TITLE
Remove RealTime Dialog Language control and allow auto-detect prompts

### DIFF
--- a/backend/tests/routes/agent-prompts.test.ts
+++ b/backend/tests/routes/agent-prompts.test.ts
@@ -102,6 +102,17 @@ describe('Agent prompt routes', () => {
       expect(body.created_at).toBeDefined();
     });
 
+    it('creates a prompt with an empty language for auto-detection', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/agent-prompts',
+        payload: { ...SEED_PROMPT, language: '' },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().language).toBe('');
+    });
+
     it('returns 400 when required fields are missing', async () => {
       const res = await app.inject({
         method: 'POST',

--- a/frontend/src/features/realtime/components/RealtimePage.test.tsx
+++ b/frontend/src/features/realtime/components/RealtimePage.test.tsx
@@ -204,9 +204,8 @@ describe("RealtimePage", () => {
     ).toBeInTheDocument();
     expect(await screen.findByDisplayValue("Marin · female")).toBeInTheDocument();
     expect(screen.getByText("Marin · female")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("English (US)")).toBeInTheDocument();
-    await user.selectOptions(screen.getByLabelText("Dialog Language"), "__custom__");
-    expect(screen.getByPlaceholderText("e.g. nl-NL")).toBeInTheDocument();
+    expect(screen.getByText("Language: en-US")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Dialog Language")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Gemini" }));
 
@@ -215,7 +214,7 @@ describe("RealtimePage", () => {
       screen.getByDisplayValue("gemini-2.5-flash-preview-native-audio-dialog"),
     ).toBeInTheDocument();
     expect(await screen.findByDisplayValue("Kore")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("Auto / provider default")).toBeDisabled();
+    expect(screen.queryByLabelText("Dialog Language")).not.toBeInTheDocument();
   });
 
   it("creates a new agent prompt inline for the active provider", async () => {
@@ -236,5 +235,27 @@ describe("RealtimePage", () => {
     await user.click(screen.getByRole("button", { name: "Save Prompt" }));
 
     expect((await screen.findAllByText("Sales rep")).length).toBeGreaterThan(0);
+  });
+
+  it("creates a prompt without a language and shows auto-detection", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(screen.getByRole("tab", { name: "ElevenLabs" }));
+    await screen.findByText("ElevenLabs Session");
+    await user.click(screen.getByRole("button", { name: "Create Prompt" }));
+    await user.type(screen.getByLabelText("Prompt title"), "Multilingual rep");
+    await user.clear(screen.getByLabelText("Language"));
+    await user.type(
+      screen.getByLabelText("Prompt body"),
+      "Act as a polite multilingual representative.",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Prompt" }));
+
+    expect(
+      (await screen.findAllByText("Multilingual rep")).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Language: Auto-detect")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/realtime/components/SessionControls.tsx
+++ b/frontend/src/features/realtime/components/SessionControls.tsx
@@ -2,14 +2,6 @@ import { useState } from "react";
 import type { AgentPrompt, Voice } from "../../../types/api.ts";
 import type { RealtimeConnectConfig } from "../hooks/useRealtimeSession.ts";
 
-const LANGUAGE_OPTIONS = [
-  { value: "en-US", label: "English (US)" },
-  { value: "en-GB", label: "English (UK)" },
-  { value: "de-DE", label: "German" },
-  { value: "fr-FR", label: "French" },
-  { value: "es-ES", label: "Spanish" },
-] as const;
-
 export interface CreatePromptDraft {
   language: string;
   prompt: string;
@@ -51,10 +43,6 @@ function formatVoiceName(voice: Voice): string {
   return [voice.name, voice.gender].filter(Boolean).join(" · ");
 }
 
-function hasLanguageOption(language: string): boolean {
-  return LANGUAGE_OPTIONS.some((option) => option.value === language);
-}
-
 export function SessionControls({
   error,
   isActive,
@@ -82,8 +70,6 @@ export function SessionControls({
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [selectedPromptId, setSelectedPromptId] = useState("");
   const [selectedVoiceId, setSelectedVoiceId] = useState("");
-  const [selectedLanguage, setSelectedLanguage] = useState("");
-  const [customLanguage, setCustomLanguage] = useState("");
   const [newPromptTitle, setNewPromptTitle] = useState("");
   const [newPromptLanguage, setNewPromptLanguage] = useState("en-US");
   const [newPromptBody, setNewPromptBody] = useState("");
@@ -97,24 +83,11 @@ export function SessionControls({
         : "";
   const selectedPrompt =
     prompts.find((prompt) => String(prompt.id) === resolvedPromptId) ?? null;
-  // Language is driven by the selected prompt. Providers in "auto-only" mode
-  // (e.g. Gemini) ignore an explicit language, so we leave it unset for them.
-  const selectedPromptLanguage = selectedPrompt?.language ?? "";
-  const languageSelectValue =
-    languageMode === "auto-only"
-      ? "__auto__"
-      : selectedLanguage ||
-        (hasLanguageOption(selectedPromptLanguage)
-          ? selectedPromptLanguage
-          : selectedPromptLanguage
-            ? "__custom__"
-            : "");
+  // Language is driven entirely by the selected prompt. A prompt with no
+  // language (and any "auto-only" provider such as Gemini) leaves it unset, so
+  // the provider auto-detects the language.
   const resolvedLanguage =
-    languageMode === "configurable"
-      ? languageSelectValue === "__custom__"
-        ? customLanguage.trim() || selectedPromptLanguage
-        : languageSelectValue
-      : "";
+    languageMode === "configurable" ? selectedPrompt?.language?.trim() ?? "" : "";
   const resolvedVoiceId =
     voices.find((voice) => voice.id === selectedVoiceId)?.id ??
     voices[0]?.id ??
@@ -156,11 +129,6 @@ export function SessionControls({
 
     if (!title) {
       setCreateError("Prompt title is required.");
-      return;
-    }
-
-    if (!language) {
-      setCreateError("Prompt language is required.");
       return;
     }
 
@@ -328,8 +296,6 @@ export function SessionControls({
             onChange={(event) => {
               setFormError(null);
               setSelectedPromptId(event.target.value);
-              setSelectedLanguage("");
-              setCustomLanguage("");
             }}
             disabled={isActive || isBusy || isPromptsLoading || prompts.length === 0}
           >
@@ -346,54 +312,7 @@ export function SessionControls({
             )}
           </select>
         </label>
-
-        <label className="flex flex-col gap-1 text-sm text-gray-600">
-          Dialog Language
-          <select
-            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
-            value={languageSelectValue}
-            onChange={(event) => {
-              const nextLanguage = event.target.value;
-              setFormError(null);
-              setSelectedLanguage(nextLanguage);
-              if (nextLanguage === "__custom__") {
-                setCustomLanguage(customLanguage || selectedPromptLanguage);
-              }
-            }}
-            disabled={isActive || isBusy || languageMode === "auto-only"}
-          >
-            {languageMode === "auto-only" ? (
-              <option value="__auto__">Auto / provider default</option>
-            ) : (
-              <>
-                {LANGUAGE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-                <option value="__custom__">Custom language code</option>
-              </>
-            )}
-          </select>
-        </label>
       </div>
-
-      {languageMode === "configurable" && languageSelectValue === "__custom__" ? (
-        <label className="mt-4 flex max-w-md flex-col gap-1 text-sm text-gray-600">
-          Custom language code
-          <input
-            type="text"
-            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
-            value={customLanguage}
-            onChange={(event) => {
-              setFormError(null);
-              setCustomLanguage(event.target.value);
-            }}
-            placeholder="e.g. nl-NL"
-            disabled={isActive || isBusy}
-          />
-        </label>
-      ) : null}
 
       {selectedPrompt ? (
         <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
@@ -403,7 +322,7 @@ export function SessionControls({
                 {selectedPrompt.title}
               </h3>
               <p className="text-xs text-gray-500">
-                Language: {selectedPrompt.language}
+                Language: {selectedPrompt.language.trim() || "Auto-detect"}
               </p>
             </div>
 
@@ -462,6 +381,7 @@ export function SessionControls({
                 className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
                 value={newPromptLanguage}
                 onChange={(event) => setNewPromptLanguage(event.target.value)}
+                placeholder="Leave empty to auto-detect"
                 disabled={isCreatingPrompt || isActive}
               />
             </label>


### PR DESCRIPTION
## Summary

Removes the manual **Dialog Language** control from the RealTime page (again) and makes the agent-prompt language optional so providers can auto-detect the spoken language.

This re-applies the intent of #85 (which #86 reverted) and goes one step further by supporting language-less prompts.

## Changes

- **Drop the Dialog Language selector** in `SessionControls`. The session language is derived solely from the selected agent prompt and stays unset for auto-only providers (e.g. Gemini). The `session_start` passthrough to the backend is preserved, so provider-side transcription hints keep working.
- **Optional prompt language** — creating an agent prompt with an empty language is now allowed. It surfaces as `Language: Auto-detect`, and the create form shows a `Leave empty to auto-detect` placeholder. With no language, the provider auto-detects input.
- No backend code changes required: the `language` column is `NOT NULL` but accepts `""`, and the create schema is `Type.String()`. A regression test locks in that an empty language is accepted.

## Validation

- `npx vitest run` (frontend) — 135 passed
- `npx vitest run` (backend) — 450 passed, incl. new "empty language for auto-detection" route test
- `npm run lint --workspace=frontend` — clean
- Playwright smoke check of `/realtime`: control gone, language shown from the prompt, create-form hint present, no console errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)