### PR TITLE
Fix OpenAI realtime input audio rate and language code

### DIFF
--- a/backend/src/providers/realtime/openai.ts
+++ b/backend/src/providers/realtime/openai.ts
@@ -152,12 +152,30 @@ function sendJson(socket: WebSocket, payload: Record<string, unknown>): Promise<
   });
 }
 
+// WebSocket close frames cap the reason at 123 bytes; an oversized reason makes
+// `ws` throw a RangeError that would otherwise crash the process. Trim by code
+// point so the UTF-8 byte length always fits.
+const MAX_CLOSE_REASON_BYTES = 123;
+
+function truncateCloseReason(reason: string): string {
+  if (Buffer.byteLength(reason) <= MAX_CLOSE_REASON_BYTES) {
+    return reason;
+  }
+
+  let truncated = reason;
+  while (truncated.length > 0 && Buffer.byteLength(truncated) > MAX_CLOSE_REASON_BYTES) {
+    truncated = truncated.slice(0, -1);
+  }
+
+  return truncated;
+}
+
 function closeSocket(socket: WebSocket, code: number, reason: string): void {
   if (socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
     return;
   }
 
-  socket.close(code, reason);
+  socket.close(code, truncateCloseReason(reason));
 }
 
 function buildSessionUpdate(config: RealtimeSessionConfig): Record<string, unknown> {

--- a/backend/src/providers/realtime/openai.ts
+++ b/backend/src/providers/realtime/openai.ts
@@ -11,7 +11,9 @@ const REALTIME_MODEL_PREFIXES = [
 
 const DEFAULT_INPUT_TRANSCRIPTION_MODEL = 'gpt-4o-mini-transcribe';
 const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
-const OPENAI_INPUT_AUDIO_RATE = 16000;
+// OpenAI Realtime requires the input PCM rate to be >= 24000; the frontend
+// microphone capture is resampled to match this value (see useMicrophone).
+const OPENAI_INPUT_AUDIO_RATE = 24000;
 const OPENAI_OUTPUT_AUDIO_RATE = 24000;
 const OPENAI_OUTPUT_AUDIO_MIME_TYPE = `audio/pcm;rate=${OPENAI_OUTPUT_AUDIO_RATE}`;
 const OPENAI_REALTIME_VOICE_IDS = [
@@ -62,6 +64,12 @@ function getErrorMessage(error: unknown, fallback: string): string {
 
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+// OpenAI Realtime transcription expects an ISO 639-1 code (e.g. "en"),
+// not a full BCP-47 tag like "en-US". Use the primary language subtag.
+function toRealtimeLanguageCode(language: string): string {
+  return language.split(/[-_]/)[0].toLowerCase();
 }
 
 function extractRealtimeError(message: Record<string, unknown>): {
@@ -170,7 +178,7 @@ function buildSessionUpdate(config: RealtimeSessionConfig): Record<string, unkno
         },
         transcription: {
           model: DEFAULT_INPUT_TRANSCRIPTION_MODEL,
-          ...(language ? { language } : {}),
+          ...(language ? { language: toRealtimeLanguageCode(language) } : {}),
         },
         turn_detection: {
           type: 'server_vad',

--- a/backend/tests/providers/openai-realtime.test.ts
+++ b/backend/tests/providers/openai-realtime.test.ts
@@ -193,14 +193,14 @@ describe('OpenAIRealtimeProvider', () => {
           input: {
             format: {
               type: 'audio/pcm',
-              rate: 16000,
+              rate: 24000,
             },
             noise_reduction: {
               type: 'near_field',
             },
             transcription: {
               model: 'gpt-4o-mini-transcribe',
-              language: 'en-US',
+              language: 'en',
             },
             turn_detection: {
               type: 'server_vad',

--- a/backend/tests/providers/openai-realtime.test.ts
+++ b/backend/tests/providers/openai-realtime.test.ts
@@ -17,6 +17,12 @@ const { MockOpenAI, MockWebSocket, mockSocketInstances } = vi.hoisted(() => {
       return true;
     });
     close = vi.fn((code?: number, reason?: string) => {
+      // Mirror the ws library: a close reason above 123 bytes throws, which
+      // would otherwise crash the process if left unhandled.
+      if (reason !== undefined && Buffer.byteLength(reason) > 123) {
+        throw new RangeError('The message must not be greater than 123 bytes');
+      }
+
       this.readyState = MockWebSocket.CLOSED;
       this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
     });
@@ -384,6 +390,42 @@ describe('OpenAIRealtimeProvider', () => {
       },
     });
     expect(socket.close).toHaveBeenCalledWith(1011, 'Invalid model');
+  });
+
+  it('truncates long upstream errors so the close frame stays within 123 bytes', async () => {
+    const onEvent = vi.fn<(event: RealtimeEvent) => void>();
+    const longMessage =
+      "Invalid value: 'en-US'. Supported values are: 'af', 'ar', 'az', 'be', " +
+      "'bg', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'es', 'et', 'fa'.";
+    const sessionPromise = provider.createSession(
+      {
+        model: 'gpt-realtime',
+        systemPrompt: 'Be concise',
+      },
+      onEvent,
+    );
+
+    const socket = mockSocketInstances[0];
+    socket.open();
+
+    // Must not throw a RangeError from the oversized close reason.
+    expect(() => {
+      socket.emitMessage({
+        type: 'error',
+        error: {
+          message: longMessage,
+        },
+      });
+    }).not.toThrow();
+
+    // The user-facing rejection keeps the full message...
+    await expect(sessionPromise).rejects.toThrow(longMessage);
+
+    // ...while the close frame reason is trimmed to <= 123 bytes.
+    expect(socket.close).toHaveBeenCalledTimes(1);
+    const [closeCode, closeReason] = socket.close.mock.calls[0];
+    expect(closeCode).toBe(1011);
+    expect(Buffer.byteLength(closeReason)).toBeLessThanOrEqual(123);
   });
 
   it('does not emit session_end when the session is closed intentionally', async () => {

--- a/frontend/src/features/realtime/components/OpenAiTab.tsx
+++ b/frontend/src/features/realtime/components/OpenAiTab.tsx
@@ -3,6 +3,7 @@ import { RealtimeProviderTab } from "./RealtimeProviderTab.tsx";
 export function OpenAiTab() {
   return (
     <RealtimeProviderTab
+      inputSampleRate={24_000}
       providerId="openai-realtime"
       providerLabel="OpenAI"
     />

--- a/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
+++ b/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
@@ -14,6 +14,9 @@ import {
 import { TranscriptionPanel } from "./TranscriptionPanel.tsx";
 
 interface RealtimeProviderTabProps {
+  // PCM rate the microphone capture is resampled to before streaming. OpenAI
+  // Realtime requires 24 kHz; other providers accept the 16 kHz default.
+  inputSampleRate?: number;
   languageMode?: "auto-only" | "configurable";
   providerId: string;
   providerLabel: string;
@@ -24,6 +27,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
 }
 
 export function RealtimeProviderTab({
+  inputSampleRate,
   languageMode = "configurable",
   providerId,
   providerLabel,
@@ -70,6 +74,7 @@ export function RealtimeProviderTab({
     try {
       await startMicrophone({
         onChunk: session.sendAudio,
+        targetSampleRate: inputSampleRate,
       });
     } catch (error) {
       await session.disconnect();

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -5,7 +5,6 @@ import { useMicrophone } from "./useMicrophone.ts";
 
 interface FakeWorkletMessage {
   data: {
-    sampleRate: number;
     samples: Float32Array;
     type?: string;
   };
@@ -28,7 +27,6 @@ class FakeAudioWorkletPort {
   flush() {
     this.onmessage?.({
       data: {
-        sampleRate: 16_000,
         samples: this.flushSamples,
         type: "flushed",
       },
@@ -71,7 +69,7 @@ function TestHarness({
       <button
         type="button"
         onClick={() => {
-          void microphone.start({ onChunk, targetSampleRate });
+          microphone.start({ onChunk, targetSampleRate }).catch(() => {});
         }}
       >
         Start
@@ -106,11 +104,17 @@ describe("useMicrophone", () => {
   const addModule = vi.fn();
   const decodeAudioData = vi.fn();
   let sourceNode: FakeMediaStreamSourceNode;
+  let audioContextOptionsLog: Array<{ sampleRate?: number } | undefined>;
+  // When set, forces every context to report this rate regardless of request,
+  // simulating a browser that cannot honor the requested sample rate.
+  let forcedContextSampleRate: number | null;
 
   beforeEach(() => {
     FakeAudioWorkletNode.instance = null;
     FakeAudioWorkletNode.shouldThrow = false;
     sourceNode = new FakeMediaStreamSourceNode();
+    audioContextOptionsLog = [];
+    forcedContextSampleRate = null;
     addModule.mockResolvedValue(undefined);
 
     getUserMedia.mockResolvedValue({
@@ -120,11 +124,17 @@ describe("useMicrophone", () => {
     class FakeAudioContext {
       readonly audioWorklet = { addModule };
       readonly destination = {};
-      readonly sampleRate = 48_000;
+      readonly sampleRate: number;
       readonly state = "running";
       close = vi.fn();
       decodeAudioData = decodeAudioData;
       resume = vi.fn();
+
+      constructor(options?: { sampleRate?: number }) {
+        audioContextOptionsLog.push(options);
+        this.sampleRate =
+          forcedContextSampleRate ?? options?.sampleRate ?? 48_000;
+      }
 
       createMediaStreamSource() {
         return sourceNode;
@@ -162,7 +172,6 @@ describe("useMicrophone", () => {
     act(() => {
       FakeAudioWorkletNode.instance?.port.onmessage?.({
         data: {
-          sampleRate: 16_000,
           samples: new Float32Array([0, 0.5, -0.5]),
           type: "chunk",
         },
@@ -178,7 +187,7 @@ describe("useMicrophone", () => {
     expect(decodeAudioData).not.toHaveBeenCalled();
   });
 
-  it("resamples capture to a custom target sample rate when provided", async () => {
+  it("captures directly at the requested target sample rate without resampling", async () => {
     const user = userEvent.setup();
     const onChunk = vi.fn();
 
@@ -187,10 +196,12 @@ describe("useMicrophone", () => {
     await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => expect(addModule).toHaveBeenCalled());
 
+    // The AudioContext is created at the target rate, so no resampling happens.
+    expect(audioContextOptionsLog).toContainEqual({ sampleRate: 24_000 });
+
     act(() => {
       FakeAudioWorkletNode.instance?.port.onmessage?.({
         data: {
-          sampleRate: 48_000,
           samples: new Float32Array([0, 0.1, 0.2, 0.3, 0.4, 0.5]),
           type: "chunk",
         },
@@ -199,45 +210,23 @@ describe("useMicrophone", () => {
 
     await waitFor(() => expect(onChunk).toHaveBeenCalledTimes(1));
 
-    // 48 kHz -> 24 kHz halves the samples: 6 floats -> 3 samples -> 6 bytes.
-    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(6);
+    // Samples pass straight through: 6 floats -> 6 samples -> 12 bytes.
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(12);
   });
 
-  it("upsamples without zero-stuffing when the source rate is below the target", async () => {
+  it("fails clearly when the browser cannot capture at the target rate", async () => {
     const user = userEvent.setup();
     const onChunk = vi.fn();
+    forcedContextSampleRate = 48_000;
 
     render(<TestHarness onChunk={onChunk} targetSampleRate={24_000} />);
 
     await user.click(screen.getByRole("button", { name: "Start" }));
-    await waitFor(() => expect(addModule).toHaveBeenCalled());
 
-    act(() => {
-      FakeAudioWorkletNode.instance?.port.onmessage?.({
-        data: {
-          // Communications devices can run the AudioContext below 24 kHz.
-          sampleRate: 16_000,
-          samples: new Float32Array([0.1, 0.4, 0.7, 1]),
-          type: "chunk",
-        },
-      });
-    });
-
-    await waitFor(() => expect(onChunk).toHaveBeenCalledTimes(1));
-
-    const pcm = onChunk.mock.calls[0]?.[0] as Uint8Array;
-    // 16 kHz -> 24 kHz grows the samples by 1.5x: 4 -> 6 samples -> 12 bytes.
-    expect(pcm).toHaveLength(12);
-
-    // A monotonically increasing input must stay monotonic; the broken
-    // downsample-only path would inject zero samples and break this.
-    const view = new DataView(pcm.buffer, pcm.byteOffset, pcm.byteLength);
-    const samples = Array.from({ length: pcm.byteLength / 2 }, (_, index) =>
-      view.getInt16(index * 2, true),
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/24000 Hz/),
     );
-    for (let index = 1; index < samples.length; index += 1) {
-      expect(samples[index]).toBeGreaterThanOrEqual(samples[index - 1]);
-    }
+    expect(onChunk).not.toHaveBeenCalled();
   });
 
   it("flushes trailing worklet samples before stopping capture", async () => {

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -57,7 +57,13 @@ class FakeMediaStreamSourceNode {
   disconnect = vi.fn();
 }
 
-function TestHarness({ onChunk }: { onChunk: (chunk: Uint8Array) => void }) {
+function TestHarness({
+  onChunk,
+  targetSampleRate,
+}: {
+  onChunk: (chunk: Uint8Array) => void;
+  targetSampleRate?: number;
+}) {
   const microphone = useMicrophone();
 
   return (
@@ -65,7 +71,7 @@ function TestHarness({ onChunk }: { onChunk: (chunk: Uint8Array) => void }) {
       <button
         type="button"
         onClick={() => {
-          void microphone.start({ onChunk });
+          void microphone.start({ onChunk, targetSampleRate });
         }}
       >
         Start
@@ -170,6 +176,31 @@ describe("useMicrophone", () => {
     expect(screen.getByTestId("chunk-count")).toHaveTextContent("1");
     expect(sourceNode.connect).toHaveBeenCalledWith(FakeAudioWorkletNode.instance);
     expect(decodeAudioData).not.toHaveBeenCalled();
+  });
+
+  it("resamples capture to a custom target sample rate when provided", async () => {
+    const user = userEvent.setup();
+    const onChunk = vi.fn();
+
+    render(<TestHarness onChunk={onChunk} targetSampleRate={24_000} />);
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(addModule).toHaveBeenCalled());
+
+    act(() => {
+      FakeAudioWorkletNode.instance?.port.onmessage?.({
+        data: {
+          sampleRate: 48_000,
+          samples: new Float32Array([0, 0.1, 0.2, 0.3, 0.4, 0.5]),
+          type: "chunk",
+        },
+      });
+    });
+
+    await waitFor(() => expect(onChunk).toHaveBeenCalledTimes(1));
+
+    // 48 kHz -> 24 kHz halves the samples: 6 floats -> 3 samples -> 6 bytes.
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(6);
   });
 
   it("flushes trailing worklet samples before stopping capture", async () => {

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -203,6 +203,43 @@ describe("useMicrophone", () => {
     expect(onChunk.mock.calls[0]?.[0]).toHaveLength(6);
   });
 
+  it("upsamples without zero-stuffing when the source rate is below the target", async () => {
+    const user = userEvent.setup();
+    const onChunk = vi.fn();
+
+    render(<TestHarness onChunk={onChunk} targetSampleRate={24_000} />);
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(addModule).toHaveBeenCalled());
+
+    act(() => {
+      FakeAudioWorkletNode.instance?.port.onmessage?.({
+        data: {
+          // Communications devices can run the AudioContext below 24 kHz.
+          sampleRate: 16_000,
+          samples: new Float32Array([0.1, 0.4, 0.7, 1]),
+          type: "chunk",
+        },
+      });
+    });
+
+    await waitFor(() => expect(onChunk).toHaveBeenCalledTimes(1));
+
+    const pcm = onChunk.mock.calls[0]?.[0] as Uint8Array;
+    // 16 kHz -> 24 kHz grows the samples by 1.5x: 4 -> 6 samples -> 12 bytes.
+    expect(pcm).toHaveLength(12);
+
+    // A monotonically increasing input must stay monotonic; the broken
+    // downsample-only path would inject zero samples and break this.
+    const view = new DataView(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+    const samples = Array.from({ length: pcm.byteLength / 2 }, (_, index) =>
+      view.getInt16(index * 2, true),
+    );
+    for (let index = 1; index < samples.length; index += 1) {
+      expect(samples[index]).toBeGreaterThanOrEqual(samples[index - 1]);
+    }
+  });
+
   it("flushes trailing worklet samples before stopping capture", async () => {
     const user = userEvent.setup();
     const onChunk =

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -21,7 +21,7 @@ class RealtimeMicrophoneProcessor extends AudioWorkletProcessor {
       : new Float32Array(0);
 
     this.port.postMessage(
-      { type: "flushed", sampleRate, samples },
+      { type: "flushed", samples },
       [samples.buffer],
     );
 
@@ -48,7 +48,7 @@ class RealtimeMicrophoneProcessor extends AudioWorkletProcessor {
       if (this.offset === this.buffer.length) {
         const samples = this.buffer;
         this.port.postMessage(
-          { type: "chunk", sampleRate, samples },
+          { type: "chunk", samples },
           [samples.buffer],
         );
         this.buffer = new Float32Array(4096);
@@ -90,76 +90,6 @@ function getAudioContextConstructor(): AudioContextConstructor | undefined {
   return window.AudioContext ?? (window as typeof window & {
     webkitAudioContext?: AudioContextConstructor;
   }).webkitAudioContext;
-}
-
-function downsampleBuffer(
-  input: Float32Array,
-  sampleRateRatio: number,
-  outputLength: number,
-): Float32Array {
-  const output = new Float32Array(outputLength);
-
-  let inputIndex = 0;
-  for (let outputIndex = 0; outputIndex < outputLength; outputIndex += 1) {
-    const nextInputIndex = Math.round((outputIndex + 1) * sampleRateRatio);
-    let sum = 0;
-    let count = 0;
-
-    for (
-      let sampleIndex = inputIndex;
-      sampleIndex < nextInputIndex && sampleIndex < input.length;
-      sampleIndex += 1
-    ) {
-      sum += input[sampleIndex];
-      count += 1;
-    }
-
-    output[outputIndex] = count > 0 ? sum / count : 0;
-    inputIndex = nextInputIndex;
-  }
-
-  return output;
-}
-
-function upsampleBuffer(
-  input: Float32Array,
-  sampleRateRatio: number,
-  outputLength: number,
-): Float32Array {
-  const output = new Float32Array(outputLength);
-
-  for (let outputIndex = 0; outputIndex < outputLength; outputIndex += 1) {
-    const sourcePosition = outputIndex * sampleRateRatio;
-    const lowerIndex = Math.floor(sourcePosition);
-    const upperIndex = Math.min(lowerIndex + 1, input.length - 1);
-    const fraction = sourcePosition - lowerIndex;
-
-    output[outputIndex] =
-      input[lowerIndex] + (input[upperIndex] - input[lowerIndex]) * fraction;
-  }
-
-  return output;
-}
-
-// Resamples mono float audio to the target rate. Downsampling averages source
-// windows (anti-aliasing); upsampling interpolates linearly. A plain
-// downsample-only path would zero-stuff when the source rate is below the
-// target, distorting the audio sent to providers like OpenAI (24 kHz).
-function resampleBuffer(
-  input: Float32Array,
-  sourceSampleRate: number,
-  targetSampleRate: number,
-): Float32Array {
-  if (sourceSampleRate === targetSampleRate || input.length === 0) {
-    return input;
-  }
-
-  const sampleRateRatio = sourceSampleRate / targetSampleRate;
-  const outputLength = Math.max(1, Math.round(input.length / sampleRateRatio));
-
-  return sourceSampleRate > targetSampleRate
-    ? downsampleBuffer(input, sampleRateRatio, outputLength)
-    : upsampleBuffer(input, sampleRateRatio, outputLength);
 }
 
 function floatToPcm16(input: Float32Array): Uint8Array {
@@ -290,8 +220,34 @@ export function useMicrophone(): UseMicrophoneResult {
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
 
+    // Capture directly at the target rate so no manual resampling is needed.
+    const existingContext = audioContextRef.current;
+    if (existingContext && existingContext.sampleRate !== targetSampleRate) {
+      await existingContext.close();
+      audioContextRef.current = null;
+    }
+
     if (!audioContextRef.current) {
-      audioContextRef.current = new AudioContextCtor();
+      let context: AudioContext;
+      try {
+        context = new AudioContextCtor({ sampleRate: targetSampleRate });
+      } catch {
+        context = new AudioContextCtor();
+      }
+
+      if (context.sampleRate !== targetSampleRate) {
+        await context.close();
+        for (const track of stream.getTracks()) {
+          track.stop();
+        }
+
+        const message =
+          `This browser cannot capture microphone audio at ${targetSampleRate} Hz.`;
+        setError(message);
+        throw new Error(message);
+      }
+
+      audioContextRef.current = context;
     }
 
     if (audioContextRef.current.state === "suspended") {
@@ -350,7 +306,6 @@ export function useMicrophone(): UseMicrophoneResult {
     setIsRecording(true);
 
     workletNode.port.onmessage = (event: MessageEvent<{
-      sampleRate?: number;
       samples?: Float32Array;
       type?: string;
     }>) => {
@@ -362,12 +317,9 @@ export function useMicrophone(): UseMicrophoneResult {
         return;
       }
 
-      const resampled = resampleBuffer(
-        event.data.samples,
-        event.data.sampleRate ?? audioContext.sampleRate,
-        targetSampleRate,
-      );
-      const pcmChunk = floatToPcm16(resampled);
+      // The context already runs at the target rate, so the samples are sent
+      // straight through without resampling.
+      const pcmChunk = floatToPcm16(event.data.samples);
 
       pendingChunkSendsRef.current = pendingChunkSendsRef.current
         .catch(() => undefined)

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const TARGET_SAMPLE_RATE = 16_000;
+const DEFAULT_TARGET_SAMPLE_RATE = 16_000;
 const MICROPHONE_WORKLET_NAME = "realtime-microphone-processor";
 const MICROPHONE_WORKLET_SOURCE = `
 class RealtimeMicrophoneProcessor extends AudioWorkletProcessor {
@@ -67,6 +67,9 @@ const loadedAudioWorklets = new WeakSet<AudioContext>();
 
 export interface UseMicrophoneStartOptions {
   onChunk?: (chunk: Uint8Array) => void | Promise<void>;
+  // PCM rate the captured audio is resampled to before being sent to the
+  // realtime provider. Defaults to 16 kHz; OpenAI Realtime requires 24 kHz.
+  targetSampleRate?: number;
 }
 
 interface UseMicrophoneResult {
@@ -233,6 +236,7 @@ export function useMicrophone(): UseMicrophoneResult {
   }, []);
 
   const start = useCallback(async (options: UseMicrophoneStartOptions = {}) => {
+    const targetSampleRate = options.targetSampleRate ?? DEFAULT_TARGET_SAMPLE_RATE;
     if (
       typeof navigator === "undefined" ||
       !navigator.mediaDevices?.getUserMedia
@@ -326,7 +330,7 @@ export function useMicrophone(): UseMicrophoneResult {
       const resampled = downsampleBuffer(
         event.data.samples,
         event.data.sampleRate ?? audioContext.sampleRate,
-        TARGET_SAMPLE_RATE,
+        targetSampleRate,
       );
       const pcmChunk = floatToPcm16(resampled);
 

--- a/frontend/src/features/realtime/hooks/useMicrophone.ts
+++ b/frontend/src/features/realtime/hooks/useMicrophone.ts
@@ -94,15 +94,9 @@ function getAudioContextConstructor(): AudioContextConstructor | undefined {
 
 function downsampleBuffer(
   input: Float32Array,
-  sourceSampleRate: number,
-  targetSampleRate: number,
+  sampleRateRatio: number,
+  outputLength: number,
 ): Float32Array {
-  if (sourceSampleRate === targetSampleRate) {
-    return input;
-  }
-
-  const sampleRateRatio = sourceSampleRate / targetSampleRate;
-  const outputLength = Math.round(input.length / sampleRateRatio);
   const output = new Float32Array(outputLength);
 
   let inputIndex = 0;
@@ -125,6 +119,47 @@ function downsampleBuffer(
   }
 
   return output;
+}
+
+function upsampleBuffer(
+  input: Float32Array,
+  sampleRateRatio: number,
+  outputLength: number,
+): Float32Array {
+  const output = new Float32Array(outputLength);
+
+  for (let outputIndex = 0; outputIndex < outputLength; outputIndex += 1) {
+    const sourcePosition = outputIndex * sampleRateRatio;
+    const lowerIndex = Math.floor(sourcePosition);
+    const upperIndex = Math.min(lowerIndex + 1, input.length - 1);
+    const fraction = sourcePosition - lowerIndex;
+
+    output[outputIndex] =
+      input[lowerIndex] + (input[upperIndex] - input[lowerIndex]) * fraction;
+  }
+
+  return output;
+}
+
+// Resamples mono float audio to the target rate. Downsampling averages source
+// windows (anti-aliasing); upsampling interpolates linearly. A plain
+// downsample-only path would zero-stuff when the source rate is below the
+// target, distorting the audio sent to providers like OpenAI (24 kHz).
+function resampleBuffer(
+  input: Float32Array,
+  sourceSampleRate: number,
+  targetSampleRate: number,
+): Float32Array {
+  if (sourceSampleRate === targetSampleRate || input.length === 0) {
+    return input;
+  }
+
+  const sampleRateRatio = sourceSampleRate / targetSampleRate;
+  const outputLength = Math.max(1, Math.round(input.length / sampleRateRatio));
+
+  return sourceSampleRate > targetSampleRate
+    ? downsampleBuffer(input, sampleRateRatio, outputLength)
+    : upsampleBuffer(input, sampleRateRatio, outputLength);
 }
 
 function floatToPcm16(input: Float32Array): Uint8Array {
@@ -327,7 +362,7 @@ export function useMicrophone(): UseMicrophoneResult {
         return;
       }
 
-      const resampled = downsampleBuffer(
+      const resampled = resampleBuffer(
         event.data.samples,
         event.data.sampleRate ?? audioContext.sampleRate,
         targetSampleRate,


### PR DESCRIPTION
## Problem

Starting an OpenAI realtime session failed, and the backend process crashed. Three related issues in the realtime `session.update` / connection path:

1. `Invalid 'session.audio.input.format.rate': integer below minimum value. Expected a value >= 24000, but got 16000 instead.`
2. `Invalid value: 'en-US'. Supported values are: ... 'en' ...`
3. The backend process crashed with `RangeError: The message must not be greater than 123 bytes` (surfaced as 502s in the UI).

## Root cause

- **Rate:** OpenAI Realtime now requires the input PCM rate to be `>= 24000`. The backend declared `rate: 16000`, and the shared `useMicrophone` hook captured at 16 kHz.
- **Language:** the transcription language was passed straight through as the prompt's BCP-47 tag (`en-US`); OpenAI expects an ISO 639-1 code (`en`).
- **Crash:** when OpenAI returned a long error before the session was ready, `failStartup` used the full message as the WebSocket close reason. Close frames cap the reason at 123 bytes, so `ws` threw an unhandled `RangeError` that took down the process. The long language error (#2) was the trigger that exposed this.

## Fix

- **Backend** (`openai.ts`): input rate -> `24000`; normalize transcription language to its primary subtag (`en-US` -> `en`); truncate the WebSocket close reason to 123 UTF-8 bytes (the full message is still surfaced via the rejection and error event).
- **Frontend** `useMicrophone`: new `targetSampleRate` option (defaults to 16 kHz). The capture `AudioContext` is created at that rate (`new AudioContext({ sampleRate })`), so the browser delivers audio at the target rate and the worklet samples are sent through unchanged — no manual resampling. If the browser cannot honor the rate, capture fails with a clear error rather than sending distorted audio.
- **RealtimeProviderTab**: new `inputSampleRate` prop wired into capture.
- **OpenAiTab**: passes `inputSampleRate={24_000}`. Gemini / ElevenLabs / Inworld keep the 16 kHz default.

## Verification

- Backend `openai-realtime` tests: 9/9 pass (rate 24000, language `en`, plus an oversized-close-reason test that reproduces the crash via a ws-accurate mock).
- Frontend `useMicrophone` tests: 6/6 pass (direct-capture rate, straight-through samples, and a clear failure when the rate is unsupported).
- Frontend lint clean.
- Manual (Playwright): a `gpt-realtime` session with an `en-US` prompt reaches **Connected / Live** and produces correct live transcripts, with no UI or console errors. The backend no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
