### PR TITLE
[codex] Add realtime prompt editing

### DIFF
--- a/frontend/src/features/realtime/api/queries.ts
+++ b/frontend/src/features/realtime/api/queries.ts
@@ -9,6 +9,12 @@ export interface CreateAgentPromptInput {
   prompt: string;
 }
 
+export interface UpdateAgentPromptInput {
+  title?: string;
+  language?: string;
+  prompt?: string;
+}
+
 export const realtimeKeys = {
   all: ["realtime"] as const,
   agentPrompts: (providerId: string | null = null) =>
@@ -39,6 +45,39 @@ export function useCreateAgentPrompt() {
   return useMutation({
     mutationFn: (input: CreateAgentPromptInput) =>
       api.post<AgentPrompt>("/agent-prompts", input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [...realtimeKeys.all, "agent-prompts"],
+      });
+    },
+  });
+}
+
+export function useUpdateAgentPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      promptId,
+      data,
+    }: {
+      promptId: number;
+      data: UpdateAgentPromptInput;
+    }) => api.put<AgentPrompt>(`/agent-prompts/${promptId}`, data),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [...realtimeKeys.all, "agent-prompts"],
+      });
+    },
+  });
+}
+
+export function useDeleteAgentPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ promptId }: { promptId: number }) =>
+      api.delete(`/agent-prompts/${promptId}`),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: [...realtimeKeys.all, "agent-prompts"],

--- a/frontend/src/features/realtime/components/RealtimePage.test.tsx
+++ b/frontend/src/features/realtime/components/RealtimePage.test.tsx
@@ -147,6 +147,44 @@ describe("RealtimePage", () => {
         return jsonResponse(nextPrompt, 201);
       }
 
+      const promptMatch = url.match(/\/agent-prompts\/(\d+)$/);
+      if (promptMatch && method === "PUT") {
+        const promptId = Number(promptMatch[1]);
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          language?: string;
+          prompt?: string;
+          title?: string;
+        };
+
+        for (const [providerId, prompts] of Object.entries(promptsByProvider)) {
+          const promptIndex = prompts.findIndex((prompt) => prompt.id === promptId);
+
+          if (promptIndex >= 0) {
+            const updatedPrompt = {
+              ...prompts[promptIndex],
+              ...body,
+            };
+            promptsByProvider[providerId] = prompts.map((prompt) =>
+              prompt.id === promptId ? updatedPrompt : prompt,
+            );
+            return jsonResponse(updatedPrompt);
+          }
+        }
+      }
+
+      if (promptMatch && method === "DELETE") {
+        const promptId = Number(promptMatch[1]);
+
+        for (const [providerId, prompts] of Object.entries(promptsByProvider)) {
+          if (prompts.some((prompt) => prompt.id === promptId)) {
+            promptsByProvider[providerId] = prompts.filter(
+              (prompt) => prompt.id !== promptId,
+            );
+            return new Response(null, { status: 204 });
+          }
+        }
+      }
+
       return jsonResponse(
         {
           statusCode: 404,
@@ -235,6 +273,52 @@ describe("RealtimePage", () => {
     await user.click(screen.getByRole("button", { name: "Save Prompt" }));
 
     expect((await screen.findAllByText("Sales rep")).length).toBeGreaterThan(0);
+  });
+
+  it("edits the selected agent prompt inline", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await screen.findByText("OpenAI Session");
+    await screen.findAllByText("OpenAI support agent");
+    await user.click(screen.getByRole("button", { name: "Edit Prompt" }));
+    await user.clear(screen.getByLabelText("Prompt title"));
+    await user.type(screen.getByLabelText("Prompt title"), "OpenAI triage agent");
+    await user.clear(screen.getByLabelText("Prompt body"));
+    await user.type(
+      screen.getByLabelText("Prompt body"),
+      "Ask one concise clarifying question before giving troubleshooting steps.",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(
+      (await screen.findAllByText("OpenAI triage agent")).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        "Ask one concise clarifying question before giving troubleshooting steps.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("deletes the selected agent prompt inline", async () => {
+    const user = userEvent.setup();
+
+    vi.stubGlobal("confirm", vi.fn(() => true));
+
+    renderPage();
+
+    await screen.findByText("OpenAI Session");
+    await screen.findAllByText("OpenAI support agent");
+    await user.click(screen.getByRole("button", { name: "Delete Prompt" }));
+
+    expect(
+      await screen.findByText(
+        "Create the first prompt for this provider to unlock live sessions.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("OpenAI support agent")).not.toBeInTheDocument();
   });
 
   it("creates a prompt without a language and shows auto-detection", async () => {

--- a/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
+++ b/frontend/src/features/realtime/components/RealtimeProviderTab.tsx
@@ -1,15 +1,18 @@
 import { useEffect, useState } from "react";
 import {
   useCreateAgentPrompt,
+  useDeleteAgentPrompt,
   useAgentPrompts,
   useRealtimeModels,
   useRealtimeVoices,
+  useUpdateAgentPrompt,
 } from "../api/queries.ts";
 import { useMicrophone } from "../hooks/useMicrophone.ts";
 import { useRealtimeSession } from "../hooks/useRealtimeSession.ts";
 import {
   SessionControls,
   type CreatePromptDraft,
+  type UpdatePromptDraft,
 } from "./SessionControls.tsx";
 import { TranscriptionPanel } from "./TranscriptionPanel.tsx";
 
@@ -31,6 +34,8 @@ export function RealtimeProviderTab({
   const [selectedModel, setSelectedModel] = useState("");
   const promptsQuery = useAgentPrompts(providerId);
   const createPrompt = useCreateAgentPrompt();
+  const updatePrompt = useUpdateAgentPrompt();
+  const deletePrompt = useDeleteAgentPrompt();
   const modelsQuery = useRealtimeModels(providerId);
   const models = modelsQuery.data ?? [];
   const resolvedModel =
@@ -57,6 +62,21 @@ export function RealtimeProviderTab({
       provider_id: providerId,
       title: draft.title,
     });
+  }
+
+  async function handleUpdatePrompt(promptId: number, draft: UpdatePromptDraft) {
+    return updatePrompt.mutateAsync({
+      promptId,
+      data: {
+        language: draft.language,
+        prompt: draft.prompt,
+        title: draft.title,
+      },
+    });
+  }
+
+  async function handleDeletePrompt(promptId: number) {
+    await deletePrompt.mutateAsync({ promptId });
   }
 
   async function handleStart(config: {
@@ -87,10 +107,17 @@ export function RealtimeProviderTab({
       <SessionControls
         error={microphoneError ?? session.error}
         isActive={session.isConnected}
-        isBusy={session.isConnecting || createPrompt.isPending}
+        isBusy={
+          session.isConnecting ||
+          createPrompt.isPending ||
+          updatePrompt.isPending ||
+          deletePrompt.isPending
+        }
         isCreatingPrompt={createPrompt.isPending}
+        isDeletingPrompt={deletePrompt.isPending}
         isModelsLoading={modelsQuery.isPending}
         isPromptsLoading={promptsQuery.isPending}
+        isUpdatingPrompt={updatePrompt.isPending}
         isVoicesLoading={voicesQuery.isPending}
         models={models}
         modelsError={
@@ -115,8 +142,10 @@ export function RealtimeProviderTab({
         }
         onModelChange={setSelectedModel}
         onCreatePrompt={handleCreatePrompt}
+        onDeletePrompt={handleDeletePrompt}
         onStart={handleStart}
         onStop={handleStop}
+        onUpdatePrompt={handleUpdatePrompt}
       />
 
       <TranscriptionPanel

--- a/frontend/src/features/realtime/components/SessionControls.tsx
+++ b/frontend/src/features/realtime/components/SessionControls.tsx
@@ -8,13 +8,21 @@ export interface CreatePromptDraft {
   title: string;
 }
 
+export interface UpdatePromptDraft {
+  language: string;
+  prompt: string;
+  title: string;
+}
+
 interface SessionControlsProps {
   error: string | null;
   isActive: boolean;
   isBusy: boolean;
   isCreatingPrompt: boolean;
+  isDeletingPrompt: boolean;
   isModelsLoading: boolean;
   isPromptsLoading: boolean;
+  isUpdatingPrompt: boolean;
   isVoicesLoading: boolean;
   languageMode: "auto-only" | "configurable";
   models: string[];
@@ -26,9 +34,14 @@ interface SessionControlsProps {
   voices: Voice[];
   voicesError: string | null;
   onCreatePrompt: (draft: CreatePromptDraft) => Promise<AgentPrompt>;
+  onDeletePrompt: (promptId: number) => Promise<void>;
   onModelChange: (model: string) => void;
   onStart: (config: RealtimeConnectConfig) => Promise<void>;
   onStop: () => Promise<void> | void;
+  onUpdatePrompt: (
+    promptId: number,
+    draft: UpdatePromptDraft,
+  ) => Promise<AgentPrompt>;
 }
 
 function formatModelName(model: string): string {
@@ -48,8 +61,10 @@ export function SessionControls({
   isActive,
   isBusy,
   isCreatingPrompt,
+  isDeletingPrompt,
   isModelsLoading,
   isPromptsLoading,
+  isUpdatingPrompt,
   isVoicesLoading,
   languageMode,
   models,
@@ -61,18 +76,25 @@ export function SessionControls({
   voices,
   voicesError,
   onCreatePrompt,
+  onDeletePrompt,
   onModelChange,
   onStart,
   onStop,
+  onUpdatePrompt,
 }: SessionControlsProps) {
   const [createError, setCreateError] = useState<string | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingPromptId, setEditingPromptId] = useState<number | null>(null);
   const [selectedPromptId, setSelectedPromptId] = useState("");
   const [selectedVoiceId, setSelectedVoiceId] = useState("");
   const [newPromptTitle, setNewPromptTitle] = useState("");
   const [newPromptLanguage, setNewPromptLanguage] = useState("en-US");
   const [newPromptBody, setNewPromptBody] = useState("");
+  const [editPromptTitle, setEditPromptTitle] = useState("");
+  const [editPromptLanguage, setEditPromptLanguage] = useState("");
+  const [editPromptBody, setEditPromptBody] = useState("");
   const resolvedModel =
     models.find((model) => model === selectedModel) ?? models[0] ?? "";
   const resolvedPromptId =
@@ -92,6 +114,8 @@ export function SessionControls({
     voices.find((voice) => voice.id === selectedVoiceId)?.id ??
     voices[0]?.id ??
     "";
+  const isEditingSelectedPrompt =
+    selectedPrompt !== null && editingPromptId === selectedPrompt.id;
 
   async function handleStart() {
     setFormError(null);
@@ -152,6 +176,73 @@ export function SessionControls({
     } catch (createPromptError) {
       setCreateError(
         getErrorMessage(createPromptError, "Unable to create the prompt."),
+      );
+    }
+  }
+
+  function handleOpenEditPrompt(prompt: AgentPrompt) {
+    setCreateError(null);
+    setEditError(null);
+    setIsCreateOpen(false);
+    setEditingPromptId(prompt.id);
+    setEditPromptTitle(prompt.title);
+    setEditPromptLanguage(prompt.language);
+    setEditPromptBody(prompt.prompt);
+  }
+
+  async function handleUpdatePrompt() {
+    setEditError(null);
+
+    if (!selectedPrompt || editingPromptId !== selectedPrompt.id) {
+      setEditError("Select a prompt before editing.");
+      return;
+    }
+
+    const title = editPromptTitle.trim();
+    const language = editPromptLanguage.trim();
+    const prompt = editPromptBody.trim();
+
+    if (!title) {
+      setEditError("Prompt title is required.");
+      return;
+    }
+
+    if (!prompt) {
+      setEditError("Prompt body is required.");
+      return;
+    }
+
+    try {
+      const updatedPrompt = await onUpdatePrompt(selectedPrompt.id, {
+        language,
+        prompt,
+        title,
+      });
+
+      setSelectedPromptId(String(updatedPrompt.id));
+      setEditingPromptId(null);
+    } catch (updatePromptError) {
+      setEditError(
+        getErrorMessage(updatePromptError, "Unable to update the prompt."),
+      );
+    }
+  }
+
+  async function handleDeletePrompt(prompt: AgentPrompt) {
+    setEditError(null);
+
+    if (!window.confirm("Delete this prompt?")) {
+      return;
+    }
+
+    try {
+      await onDeletePrompt(prompt.id);
+      setSelectedPromptId("");
+      setEditingPromptId(null);
+      setIsCreateOpen(false);
+    } catch (deletePromptError) {
+      setEditError(
+        getErrorMessage(deletePromptError, "Unable to delete the prompt."),
       );
     }
   }
@@ -295,6 +386,8 @@ export function SessionControls({
             value={resolvedPromptId}
             onChange={(event) => {
               setFormError(null);
+              setEditError(null);
+              setEditingPromptId(null);
               setSelectedPromptId(event.target.value);
             }}
             disabled={isActive || isBusy || isPromptsLoading || prompts.length === 0}
@@ -314,7 +407,75 @@ export function SessionControls({
         </label>
       </div>
 
-      {selectedPrompt ? (
+      {selectedPrompt && isEditingSelectedPrompt ? (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 p-4">
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_12rem]">
+            <label className="flex flex-col gap-1 text-sm text-gray-600">
+              Prompt title
+              <input
+                type="text"
+                className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                value={editPromptTitle}
+                onChange={(event) => setEditPromptTitle(event.target.value)}
+                disabled={isUpdatingPrompt || isDeletingPrompt || isActive}
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm text-gray-600">
+              Language
+              <input
+                type="text"
+                className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+                value={editPromptLanguage}
+                onChange={(event) => setEditPromptLanguage(event.target.value)}
+                placeholder="Leave empty to auto-detect"
+                disabled={isUpdatingPrompt || isDeletingPrompt || isActive}
+              />
+            </label>
+          </div>
+
+          <label className="mt-4 flex flex-col gap-1 text-sm text-gray-600">
+            Prompt body
+            <textarea
+              className="min-h-32 rounded-xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900"
+              value={editPromptBody}
+              onChange={(event) => setEditPromptBody(event.target.value)}
+              disabled={isUpdatingPrompt || isDeletingPrompt || isActive}
+            />
+          </label>
+
+          {editError ? (
+            <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {editError}
+            </div>
+          ) : null}
+
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              type="button"
+              className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => {
+                void handleUpdatePrompt();
+              }}
+              disabled={isUpdatingPrompt || isDeletingPrompt || isActive}
+            >
+              {isUpdatingPrompt ? "Saving..." : "Save Changes"}
+            </button>
+
+            <button
+              type="button"
+              className="rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => {
+                setEditError(null);
+                setEditingPromptId(null);
+              }}
+              disabled={isUpdatingPrompt || isDeletingPrompt}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : selectedPrompt ? (
         <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
           <div className="flex items-center justify-between gap-3">
             <div>
@@ -326,22 +487,52 @@ export function SessionControls({
               </p>
             </div>
 
-            <button
-              type="button"
-              className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-white"
-              onClick={() => {
-                setCreateError(null);
-                setIsCreateOpen((current) => !current);
-              }}
-              disabled={isActive || isBusy}
-            >
-              {isCreateOpen ? "Hide Create Form" : "Create Prompt"}
-            </button>
+            <div className="flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-white"
+                onClick={() => handleOpenEditPrompt(selectedPrompt)}
+                disabled={isActive || isBusy}
+              >
+                Edit Prompt
+              </button>
+
+              <button
+                type="button"
+                className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition hover:bg-red-50"
+                onClick={() => {
+                  void handleDeletePrompt(selectedPrompt);
+                }}
+                disabled={isActive || isBusy}
+              >
+                {isDeletingPrompt ? "Deleting..." : "Delete Prompt"}
+              </button>
+
+              <button
+                type="button"
+                className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-white"
+                onClick={() => {
+                  setCreateError(null);
+                  setEditError(null);
+                  setEditingPromptId(null);
+                  setIsCreateOpen((current) => !current);
+                }}
+                disabled={isActive || isBusy}
+              >
+                {isCreateOpen ? "Hide Create Form" : "Create Prompt"}
+              </button>
+            </div>
           </div>
 
           <p className="mt-3 whitespace-pre-wrap text-sm text-gray-700">
             {selectedPrompt.prompt}
           </p>
+
+          {editError ? (
+            <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {editError}
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">


### PR DESCRIPTION
## Summary

Adds inline editing and deletion for agent prompts on the Realtime page. The frontend now uses the existing agent prompt update and delete API endpoints, keeps prompt queries refreshed after mutations, and exposes edit/delete controls next to the selected prompt.

## Impact

Users can manage realtime agent prompts without leaving the Realtime workflow. Prompt updates keep the edited prompt selected, and deleting a prompt clears the selection so the provider can fall back to the next available prompt or the first-prompt empty state.

## Validation

- `npm test --workspace=frontend -- RealtimePage.test.tsx`
- `npm run lint --workspace=frontend`
- `npm run build --workspace=frontend`
- Playwright screenshot check of `/realtime`
- Headless browser console check: no warnings or errors