### PR TITLE
feat: Voice Matcher — find the closest Standard voice for a Gemini reference (#90)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ const navItems = [
   { to: "/realtime", label: "Realtime" },
   { to: "/realtime-gemini", label: "Realtime Gemini" },
   { to: "/providers", label: "Providers" },
+  { to: "/voice-matcher", label: "Voice Matcher" },
 ];
 
 export function Sidebar() {

--- a/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
+++ b/frontend/src/features/realtime/hooks/useMicrophone.test.tsx
@@ -276,12 +276,15 @@ describe("useMicrophone", () => {
     expect(secondStop).toBe(firstStop);
     expect(workletNode!.port.postMessage).toHaveBeenCalledTimes(1);
 
-    act(() => {
+    // Resolve the deferred flush AND await the stop promise inside act(): stop()
+    // calls setIsRecording(false) only after the flush resolves, so awaiting it
+    // outside act() leaks that state update past this test and intermittently
+    // destabilizes the next one ("stops the acquired stream …").
+    await act(async () => {
       workletNode!.port.flush();
+      await firstStop;
+      await secondStop;
     });
-
-    await firstStop;
-    await secondStop;
     expect(workletNode!.disconnect).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.test.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestWrapper } from "../../test-utils.tsx";
@@ -9,6 +9,31 @@ function jsonResponse(body: unknown) {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+interface FakeAudio {
+  src: string;
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  onended: (() => void) | null;
+  triggerEnded: () => void;
+}
+
+let audioInstances: FakeAudio[];
+
+function stubAudio() {
+  audioInstances = [];
+  vi.stubGlobal(
+    "Audio",
+    vi.fn(function (this: FakeAudio) {
+      this.src = "";
+      this.play = vi.fn(() => Promise.resolve());
+      this.pause = vi.fn();
+      this.onended = null;
+      this.triggerEnded = () => this.onended?.();
+      audioInstances.push(this);
+    }),
+  );
 }
 
 const geminiVoices = [
@@ -23,15 +48,7 @@ const standardVoices = [
 ];
 
 beforeEach(() => {
-  vi.stubGlobal(
-    "Audio",
-    vi.fn(() => ({
-      play: vi.fn(() => Promise.resolve()),
-      pause: vi.fn(),
-      set onended(_fn: unknown) {},
-      src: "",
-    })),
-  );
+  stubAudio();
   vi.stubGlobal("URL", {
     ...globalThis.URL,
     createObjectURL: vi.fn(() => "blob:mock"),
@@ -92,5 +109,109 @@ describe("VoiceMatcherPage", () => {
     // Female reference -> female + neutral/undefined candidates only.
     expect(await screen.findByText("en-US-Standard-C")).toBeInTheDocument();
     expect(screen.queryByText("en-US-Standard-A")).not.toBeInTheDocument();
+  });
+
+  it("single-card play does not resume the play-all sequence", async () => {
+    const user = userEvent.setup();
+    render(<VoiceMatcherPage />, { wrapper: createTestWrapper() });
+
+    await screen.findByRole("option", { name: "Kore" });
+    await user.selectOptions(screen.getByLabelText("Reference voice"), "Kore");
+    await user.selectOptions(screen.getByLabelText("Standard locale"), "en-US");
+    await user.type(screen.getByLabelText("Phrase"), "hello");
+    await user.click(
+      screen.getByRole("button", { name: /synthesize and compare/i }),
+    );
+
+    // Wait for both results (reference Kore + candidate en-US-Standard-C) to finish.
+    await screen.findByText("en-US-Standard-C");
+
+    // Start "play all" — this installs an onended chaining handler.
+    await user.click(
+      screen.getByRole("button", { name: /play all in sequence/i }),
+    );
+
+    const audio = audioInstances[0];
+    expect(audio).toBeDefined();
+    expect(audio.onended).not.toBeNull();
+
+    // Now click a single card's play. This must clear the stale onended chain.
+    const playButtons = screen.getAllByRole("button", { name: /^play$/i });
+    await user.click(playButtons[0]);
+
+    // onended must have been cleared so a single play does NOT advance the queue.
+    expect(audio.onended).toBeNull();
+
+    const playCallsBefore = audio.play.mock.calls.length;
+    audio.triggerEnded();
+    expect(audio.play.mock.calls.length).toBe(playCallsBefore);
+  });
+
+  it("disables the synth button while a batch is running", async () => {
+    let resolveSynth: ((value: Response) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/api/tts/gemini-tts/voices")) {
+          return jsonResponse(geminiVoices);
+        }
+        if (url.includes("/api/tts/google/voices")) {
+          return jsonResponse(standardVoices);
+        }
+        if (url.includes("/synthesize")) {
+          return new Promise<Response>((resolve) => {
+            resolveSynth = resolve;
+          });
+        }
+        return jsonResponse({ message: "Not Found" });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<VoiceMatcherPage />, { wrapper: createTestWrapper() });
+
+    await screen.findByRole("option", { name: "Kore" });
+    await user.selectOptions(screen.getByLabelText("Reference voice"), "Kore");
+    await user.selectOptions(screen.getByLabelText("Standard locale"), "en-US");
+    await user.type(screen.getByLabelText("Phrase"), "hello");
+
+    const button = screen.getByRole("button", {
+      name: /synthesize and compare/i,
+    });
+    expect(button).toBeEnabled();
+
+    await user.click(button);
+
+    // The batch is in flight (fetch never resolved) -> button disabled.
+    await waitFor(() => expect(button).toBeDisabled());
+
+    // Let the in-flight request settle to avoid act warnings.
+    resolveSynth?.(new Response(new Blob(["audio"]), { status: 200 }));
+  });
+
+  it("surfaces a locale load error when the Standard voices request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/api/tts/gemini-tts/voices")) {
+          return jsonResponse(geminiVoices);
+        }
+        if (url.includes("/api/tts/google/voices")) {
+          return new Response(JSON.stringify({ message: "boom" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return jsonResponse({ message: "Not Found" });
+      }),
+    );
+
+    render(<VoiceMatcherPage />, { wrapper: createTestWrapper() });
+
+    expect(
+      await screen.findByText("Failed to load locales."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.test.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -145,6 +146,47 @@ describe("VoiceMatcherPage", () => {
     const playCallsBefore = audio.play.mock.calls.length;
     audio.triggerEnded();
     expect(audio.play.mock.calls.length).toBe(playCallsBefore);
+  });
+
+  it("completes synthesis under StrictMode (results become playable, not stuck)", async () => {
+    const user = userEvent.setup();
+    render(
+      <StrictMode>
+        <VoiceMatcherPage />
+      </StrictMode>,
+      { wrapper: createTestWrapper() },
+    );
+
+    await screen.findByRole("option", { name: "Kore" });
+    await user.selectOptions(screen.getByLabelText("Reference voice"), "Kore");
+    await user.selectOptions(screen.getByLabelText("Standard locale"), "en-US");
+    await user.type(screen.getByLabelText("Phrase"), "hello");
+    await user.click(
+      screen.getByRole("button", { name: /synthesize and compare/i }),
+    );
+
+    // The candidate card renders…
+    await screen.findByText("en-US-Standard-C");
+
+    // …and synthesis must actually finish: the per-card Play buttons become
+    // enabled (status "done") rather than staying stuck on "Synthesizing…".
+    // Regression: a reset-on-input effect used to abort the freshly started
+    // batch under StrictMode's deferred/double-invoked passive effects.
+    await waitFor(() => {
+      const playButtons = screen.getAllByRole("button", { name: /^play$/i });
+      expect(playButtons.length).toBeGreaterThan(0);
+      for (const btn of playButtons) {
+        expect(btn).toBeEnabled();
+      }
+    });
+    expect(screen.queryByText("Synthesizing…")).not.toBeInTheDocument();
+
+    // The synth button is usable again once the batch settled.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /synthesize and compare/i }),
+      ).toBeEnabled(),
+    );
   });
 
   it("disables the synth button while a batch is running", async () => {

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.test.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestWrapper } from "../../test-utils.tsx";
+import { VoiceMatcherPage } from "./VoiceMatcherPage.tsx";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const geminiVoices = [
+  { id: "Kore", name: "Kore", language: "multi", gender: "female" },
+  { id: "Puck", name: "Puck", language: "multi", gender: "male" },
+];
+
+const standardVoices = [
+  { id: "en-US-Standard-A", name: "en-US-Standard-A", language: "en-US", gender: "male" },
+  { id: "en-US-Standard-C", name: "en-US-Standard-C", language: "en-US", gender: "female" },
+  { id: "de-DE-Standard-A", name: "de-DE-Standard-A", language: "de-DE", gender: "female" },
+];
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "Audio",
+    vi.fn(() => ({
+      play: vi.fn(() => Promise.resolve()),
+      pause: vi.fn(),
+      set onended(_fn: unknown) {},
+      src: "",
+    })),
+  );
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => "blob:mock"),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/tts/gemini-tts/voices")) {
+        return jsonResponse(geminiVoices);
+      }
+      if (url.includes("/api/tts/google/voices")) {
+        return jsonResponse(standardVoices);
+      }
+      if (url.includes("/synthesize")) {
+        return new Response(new Blob(["audio"]), { status: 200 });
+      }
+      return jsonResponse({ message: "Not Found" });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("VoiceMatcherPage", () => {
+  it("renders the heading", () => {
+    render(<VoiceMatcherPage />, { wrapper: createTestWrapper() });
+    expect(
+      screen.getByRole("heading", { name: "Voice Matcher" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the synth button when text is empty", async () => {
+    render(<VoiceMatcherPage />, { wrapper: createTestWrapper() });
+    await screen.findByRole("option", { name: "Kore" });
+    expect(
+      screen.getByRole("button", { name: /synthesize and compare/i }),
+    ).toBeDisabled();
+  });
+
+  it("derives candidates from locale + reference gender", async () => {
+    const user = userEvent.setup();
+    render(<VoiceMatcherPage />, { wrapper: createTestWrapper() });
+
+    await screen.findByRole("option", { name: "Kore" });
+    // Kore is female -> exclude male candidates; pick en-US locale.
+    await user.selectOptions(screen.getByLabelText("Reference voice"), "Kore");
+    await user.selectOptions(screen.getByLabelText("Standard locale"), "en-US");
+    await user.type(screen.getByLabelText("Phrase"), "hello");
+
+    await user.click(
+      screen.getByRole("button", { name: /synthesize and compare/i }),
+    );
+
+    // Female reference -> female + neutral/undefined candidates only.
+    expect(await screen.findByText("en-US-Standard-C")).toBeInTheDocument();
+    expect(screen.queryByText("en-US-Standard-A")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
@@ -34,12 +34,14 @@ export function VoiceMatcherPage() {
       ? selectedVoice.gender
       : null;
 
-  const { locales, candidates } = useStandardCandidates(
-    locale,
-    referenceGender,
-  );
+  const {
+    locales,
+    candidates,
+    isLoading: localesLoading,
+    isError: localesError,
+  } = useStandardCandidates(locale, referenceGender);
 
-  const { results, start, reset } = useBatchSynthesis(CONCURRENCY);
+  const { results, isRunning, start, reset } = useBatchSynthesis(CONCURRENCY);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -54,6 +56,9 @@ export function VoiceMatcherPage() {
     if (!audioRef.current) {
       audioRef.current = new Audio();
     }
+    // Clear any chaining handler left over from a previous "play all" so a
+    // single-card play does NOT resume the sequence.
+    audioRef.current.onended = null;
     audioRef.current.src = url;
     void audioRef.current.play();
   }
@@ -100,7 +105,10 @@ export function VoiceMatcherPage() {
   }
 
   const canSubmit =
-    voiceId !== null && locale !== null && text.trim() !== "";
+    voiceId !== null &&
+    locale !== null &&
+    text.trim() !== "" &&
+    !isRunning;
 
   useEffect(() => {
     return () => {
@@ -125,7 +133,13 @@ export function VoiceMatcherPage() {
           }}
           onVoiceChange={setVoiceId}
         />
-        <LocaleSelector locales={locales} value={locale} onChange={setLocale} />
+        <LocaleSelector
+          locales={locales}
+          value={locale}
+          onChange={setLocale}
+          isLoading={localesLoading}
+          isError={localesError}
+        />
         <TextInput value={text} onChange={setText} />
 
         <button

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
@@ -175,6 +175,7 @@ export function VoiceMatcherPage() {
           results={results}
           onPlay={play}
           onPlayAll={playAll}
+          isRunning={isRunning}
         />
       ) : null}
     </div>

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
@@ -1,7 +1,152 @@
+import { useEffect, useRef, useState } from "react";
+import { useGeminiVoices } from "./api/queries.ts";
+import { LocaleSelector } from "./components/LocaleSelector.tsx";
+import { ReferencePicker } from "./components/ReferencePicker.tsx";
+import { ResultsList } from "./components/ResultsList.tsx";
+import { TextInput } from "./components/TextInput.tsx";
+import {
+  useStandardCandidates,
+  type ReferenceGender,
+} from "./hooks/useStandardCandidates.ts";
+import {
+  useBatchSynthesis,
+  type SynthesisJob,
+} from "./hooks/useBatchSynthesis.ts";
+import {
+  synthesizeCandidate,
+  synthesizeReference,
+} from "./lib/synthesize.ts";
+
+const DEFAULT_MODEL = "gemini-2.5-flash-preview-tts";
+const CONCURRENCY = 3;
+
 export function VoiceMatcherPage() {
+  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [voiceId, setVoiceId] = useState<string | null>(null);
+  const [locale, setLocale] = useState<string | null>(null);
+  const [text, setText] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const { data: geminiVoices } = useGeminiVoices(model);
+  const selectedVoice = (geminiVoices ?? []).find((v) => v.id === voiceId);
+  const referenceGender: ReferenceGender | null =
+    selectedVoice?.gender === "male" || selectedVoice?.gender === "female"
+      ? selectedVoice.gender
+      : null;
+
+  const { locales, candidates } = useStandardCandidates(
+    locale,
+    referenceGender,
+  );
+
+  const { results, start, reset } = useBatchSynthesis(CONCURRENCY);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Reset the batch whenever any synthesis input changes.
+  useEffect(() => {
+    reset();
+    setSubmitted(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, voiceId, locale, text]);
+
+  function play(url: string) {
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+    }
+    audioRef.current.src = url;
+    void audioRef.current.play();
+  }
+
+  function playAll() {
+    if (!voiceId) return;
+    const order = [voiceId, ...candidates.map((c) => c.id)];
+    const urls = order
+      .map((label) => results[label]?.url)
+      .filter((u): u is string => u !== undefined);
+    if (urls.length === 0) return;
+
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+    }
+    const audio = audioRef.current;
+    let i = 0;
+    const playNext = () => {
+      if (i >= urls.length) {
+        audio.onended = null;
+        return;
+      }
+      audio.src = urls[i++];
+      audio.onended = playNext;
+      void audio.play();
+    };
+    playNext();
+  }
+
+  function handleSubmit() {
+    if (!voiceId || !locale || text.trim() === "") return;
+    const jobs: SynthesisJob[] = [
+      {
+        key: voiceId,
+        run: (signal) => synthesizeReference(voiceId, text, model, signal),
+      },
+      ...candidates.map<SynthesisJob>((c) => ({
+        key: c.id,
+        run: (signal) => synthesizeCandidate(c.id, text, signal),
+      })),
+    ];
+    setSubmitted(true);
+    start(jobs);
+  }
+
+  const canSubmit =
+    voiceId !== null && locale !== null && text.trim() !== "";
+
+  useEffect(() => {
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
+    };
+  }, []);
+
   return (
-    <div className="p-6">
+    <div className="flex flex-col gap-6 p-6">
       <h1 className="text-2xl font-semibold text-gray-900">Voice Matcher</h1>
+
+      <div className="grid max-w-xl gap-4">
+        <ReferencePicker
+          model={model}
+          voiceId={voiceId}
+          onModelChange={(m) => {
+            setModel(m);
+            setVoiceId(null);
+          }}
+          onVoiceChange={setVoiceId}
+        />
+        <LocaleSelector locales={locales} value={locale} onChange={setLocale} />
+        <TextInput value={text} onChange={setText} />
+
+        <button
+          type="button"
+          className="w-fit rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-40"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+        >
+          Synthesize and compare
+        </button>
+      </div>
+
+      {submitted && voiceId ? (
+        <ResultsList
+          referenceLabel={voiceId}
+          candidateLabels={candidates.map((c) => c.id)}
+          results={results}
+          onPlay={play}
+          onPlayAll={playAll}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
@@ -45,12 +45,15 @@ export function VoiceMatcherPage() {
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
-  // Reset the batch whenever any synthesis input changes.
-  useEffect(() => {
+  // Reset the batch whenever the user changes a synthesis input. This is done
+  // synchronously in the change handlers (not via an effect on the inputs):
+  // a deferred reset effect would abort the batch that handleSubmit just
+  // started, leaving every card stuck on "Synthesizing…" (the reset would run
+  // after start() in the same render commit).
+  function resetOutput() {
     reset();
     setSubmitted(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [model, voiceId, locale, text]);
+  }
 
   function play(url: string) {
     if (!audioRef.current) {
@@ -130,17 +133,30 @@ export function VoiceMatcherPage() {
           onModelChange={(m) => {
             setModel(m);
             setVoiceId(null);
+            resetOutput();
           }}
-          onVoiceChange={setVoiceId}
+          onVoiceChange={(v) => {
+            setVoiceId(v);
+            resetOutput();
+          }}
         />
         <LocaleSelector
           locales={locales}
           value={locale}
-          onChange={setLocale}
+          onChange={(l) => {
+            setLocale(l);
+            resetOutput();
+          }}
           isLoading={localesLoading}
           isError={localesError}
         />
-        <TextInput value={text} onChange={setText} />
+        <TextInput
+          value={text}
+          onChange={(t) => {
+            setText(t);
+            resetOutput();
+          }}
+        />
 
         <button
           type="button"

--- a/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
+++ b/frontend/src/features/voice-matcher/VoiceMatcherPage.tsx
@@ -1,0 +1,7 @@
+export function VoiceMatcherPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Voice Matcher</h1>
+    </div>
+  );
+}

--- a/frontend/src/features/voice-matcher/api/queries.test.tsx
+++ b/frontend/src/features/voice-matcher/api/queries.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestWrapper } from "../../../test-utils.tsx";
+import { useGeminiVoices, useStandardVoices } from "./queries.ts";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const standardVoices = [
+  { id: "en-US-Standard-A", name: "en-US-Standard-A", language: "en-US", gender: "male" },
+  { id: "en-US-Standard-C", name: "en-US-Standard-C", language: "en-US", gender: "female" },
+];
+
+const geminiVoices = [
+  { id: "Kore", name: "Kore", language: "multi", gender: "female" },
+  { id: "Puck", name: "Puck", language: "multi", gender: "male" },
+];
+
+describe("voice-matcher queries", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/api/tts/google/voices")) {
+          return jsonResponse(standardVoices);
+        }
+        if (url.includes("/api/tts/gemini-tts/voices")) {
+          return jsonResponse(geminiVoices);
+        }
+        return jsonResponse({ message: "Not Found" }, 404);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("useStandardVoices fetches the google Standard list", async () => {
+    const { result } = renderHook(() => useStandardVoices(), {
+      wrapper: createTestWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(standardVoices);
+  });
+
+  it("useGeminiVoices is disabled until a model is provided", () => {
+    const { result } = renderHook(() => useGeminiVoices(null), {
+      wrapper: createTestWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("useGeminiVoices fetches voices for the given model", async () => {
+    const { result } = renderHook(
+      () => useGeminiVoices("gemini-2.5-flash-preview-tts"),
+      { wrapper: createTestWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(geminiVoices);
+  });
+});

--- a/frontend/src/features/voice-matcher/api/queries.ts
+++ b/frontend/src/features/voice-matcher/api/queries.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../lib/api-client.ts";
+import type { Voice } from "../../../types/api.ts";
+
+export const REFERENCE_PROVIDER_ID = "gemini-tts";
+export const CANDIDATE_PROVIDER_ID = "google";
+export const STANDARD_MODEL = "Standard";
+
+export const voiceMatcherKeys = {
+  standardVoices: () =>
+    ["voice-matcher", "voices", CANDIDATE_PROVIDER_ID, STANDARD_MODEL] as const,
+  geminiVoices: (model: string) =>
+    ["voice-matcher", "voices", REFERENCE_PROVIDER_ID, model] as const,
+};
+
+export function useStandardVoices() {
+  return useQuery({
+    queryKey: voiceMatcherKeys.standardVoices(),
+    queryFn: () =>
+      api.get<Voice[]>(
+        `/tts/${CANDIDATE_PROVIDER_ID}/voices?model=${encodeURIComponent(STANDARD_MODEL)}`,
+      ),
+  });
+}
+
+export function useGeminiVoices(model: string | null) {
+  return useQuery({
+    queryKey: voiceMatcherKeys.geminiVoices(model ?? ""),
+    queryFn: () =>
+      api.get<Voice[]>(
+        `/tts/${REFERENCE_PROVIDER_ID}/voices?model=${encodeURIComponent(model ?? "")}`,
+      ),
+    enabled: model !== null,
+  });
+}

--- a/frontend/src/features/voice-matcher/components/LocaleSelector.test.tsx
+++ b/frontend/src/features/voice-matcher/components/LocaleSelector.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LocaleSelector } from "./LocaleSelector.tsx";
+
+describe("LocaleSelector", () => {
+  it("renders an error message when status is error", () => {
+    render(
+      <LocaleSelector
+        locales={[]}
+        value={null}
+        onChange={() => {}}
+        isLoading={false}
+        isError
+      />,
+    );
+    expect(screen.getByText("Failed to load locales.")).toBeInTheDocument();
+  });
+
+  it("renders a loading indicator while loading", () => {
+    render(
+      <LocaleSelector
+        locales={[]}
+        value={null}
+        onChange={() => {}}
+        isLoading
+        isError={false}
+      />,
+    );
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Failed to load locales."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the locale options when loaded", () => {
+    render(
+      <LocaleSelector
+        locales={["en-US", "de-DE"]}
+        value={null}
+        onChange={() => {}}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+    expect(screen.getByRole("option", { name: "en-US" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "de-DE" })).toBeInTheDocument();
+    expect(
+      screen.queryByText("Failed to load locales."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/voice-matcher/components/LocaleSelector.tsx
+++ b/frontend/src/features/voice-matcher/components/LocaleSelector.tsx
@@ -1,0 +1,32 @@
+interface LocaleSelectorProps {
+  locales: string[];
+  value: string | null;
+  onChange: (locale: string) => void;
+}
+
+export function LocaleSelector({
+  locales,
+  value,
+  onChange,
+}: LocaleSelectorProps) {
+  return (
+    <label className="flex flex-col gap-1 text-sm text-gray-700">
+      <span>Standard locale</span>
+      <select
+        aria-label="Standard locale"
+        className="rounded border border-gray-300 px-2 py-1"
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="" disabled>
+          {locales.length === 0 ? "Loading…" : "Select a locale"}
+        </option>
+        {locales.map((loc) => (
+          <option key={loc} value={loc}>
+            {loc}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/features/voice-matcher/components/LocaleSelector.tsx
+++ b/frontend/src/features/voice-matcher/components/LocaleSelector.tsx
@@ -2,12 +2,16 @@ interface LocaleSelectorProps {
   locales: string[];
   value: string | null;
   onChange: (locale: string) => void;
+  isLoading: boolean;
+  isError: boolean;
 }
 
 export function LocaleSelector({
   locales,
   value,
   onChange,
+  isLoading,
+  isError,
 }: LocaleSelectorProps) {
   return (
     <label className="flex flex-col gap-1 text-sm text-gray-700">
@@ -16,10 +20,11 @@ export function LocaleSelector({
         aria-label="Standard locale"
         className="rounded border border-gray-300 px-2 py-1"
         value={value ?? ""}
+        disabled={isLoading || isError}
         onChange={(e) => onChange(e.target.value)}
       >
         <option value="" disabled>
-          {locales.length === 0 ? "Loading…" : "Select a locale"}
+          {isLoading ? "Loading…" : "Select a locale"}
         </option>
         {locales.map((loc) => (
           <option key={loc} value={loc}>
@@ -27,6 +32,10 @@ export function LocaleSelector({
           </option>
         ))}
       </select>
+
+      {isError ? (
+        <p className="text-sm text-red-600">Failed to load locales.</p>
+      ) : null}
     </label>
   );
 }

--- a/frontend/src/features/voice-matcher/components/ReferencePicker.test.tsx
+++ b/frontend/src/features/voice-matcher/components/ReferencePicker.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestWrapper } from "../../../test-utils.tsx";
+import { ReferencePicker } from "./ReferencePicker.tsx";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const geminiVoices = [
+  { id: "Kore", name: "Kore", language: "multi", gender: "female" },
+  { id: "Puck", name: "Puck", language: "multi", gender: "male" },
+];
+
+describe("ReferencePicker", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(geminiVoices)),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders model and voice selects and shows the gender badge for the selected voice", async () => {
+    render(
+      <ReferencePicker
+        model="gemini-2.5-flash-preview-tts"
+        voiceId="Kore"
+        onModelChange={() => {}}
+        onVoiceChange={() => {}}
+      />,
+      { wrapper: createTestWrapper() },
+    );
+
+    expect(
+      await screen.findByRole("option", { name: "Kore" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Reference model")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reference voice")).toBeInTheDocument();
+    expect(screen.getByText("female")).toBeInTheDocument();
+  });
+
+  it("calls onVoiceChange when the voice select changes", async () => {
+    const onVoiceChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker
+        model="gemini-2.5-flash-preview-tts"
+        voiceId="Kore"
+        onModelChange={() => {}}
+        onVoiceChange={onVoiceChange}
+      />,
+      { wrapper: createTestWrapper() },
+    );
+
+    await screen.findByRole("option", { name: "Puck" });
+    await user.selectOptions(screen.getByLabelText("Reference voice"), "Puck");
+    expect(onVoiceChange).toHaveBeenCalledWith("Puck");
+  });
+});

--- a/frontend/src/features/voice-matcher/components/ReferencePicker.tsx
+++ b/frontend/src/features/voice-matcher/components/ReferencePicker.tsx
@@ -1,0 +1,76 @@
+import type { Voice } from "../../../types/api.ts";
+import { useGeminiVoices } from "../api/queries.ts";
+
+const REFERENCE_MODELS = [
+  "gemini-2.5-flash-preview-tts",
+  "gemini-2.5-pro-preview-tts",
+  "gemini-3.1-flash-tts-preview",
+] as const;
+
+interface ReferencePickerProps {
+  model: string;
+  voiceId: string | null;
+  onModelChange: (model: string) => void;
+  onVoiceChange: (voiceId: string) => void;
+}
+
+export function ReferencePicker({
+  model,
+  voiceId,
+  onModelChange,
+  onVoiceChange,
+}: ReferencePickerProps) {
+  const { data, isLoading, isError } = useGeminiVoices(model);
+  const voices: Voice[] = data ?? [];
+  const selected = voices.find((v) => v.id === voiceId);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="flex flex-col gap-1 text-sm text-gray-700">
+        <span>Reference model</span>
+        <select
+          aria-label="Reference model"
+          className="rounded border border-gray-300 px-2 py-1"
+          value={model}
+          onChange={(e) => onModelChange(e.target.value)}
+        >
+          {REFERENCE_MODELS.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm text-gray-700">
+        <span>Reference voice</span>
+        <select
+          aria-label="Reference voice"
+          className="rounded border border-gray-300 px-2 py-1"
+          value={voiceId ?? ""}
+          disabled={isLoading || isError}
+          onChange={(e) => onVoiceChange(e.target.value)}
+        >
+          <option value="" disabled>
+            {isLoading ? "Loading…" : "Select a voice"}
+          </option>
+          {voices.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {selected?.gender ? (
+        <span className="w-fit rounded bg-gray-100 px-2 py-1 text-xs text-gray-700">
+          {selected.gender}
+        </span>
+      ) : null}
+
+      {isError ? (
+        <p className="text-sm text-red-600">Failed to load reference voices.</p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/voice-matcher/components/ResultsList.test.tsx
+++ b/frontend/src/features/voice-matcher/components/ResultsList.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ResultsList } from "./ResultsList.tsx";
+import type { ResultMap } from "../hooks/useBatchSynthesis.ts";
+
+const results: ResultMap = {
+  Kore: { status: "done", url: "blob:ref" },
+  "en-US-Standard-A": { status: "done", url: "blob:a" },
+  "en-US-Standard-C": { status: "done", url: "blob:c" },
+};
+
+describe("ResultsList", () => {
+  it("renders the reference card and one card per candidate", () => {
+    render(
+      <ResultsList
+        referenceLabel="Kore"
+        candidateLabels={["en-US-Standard-A", "en-US-Standard-C"]}
+        results={results}
+        onPlay={() => {}}
+        onPlayAll={() => {}}
+      />,
+    );
+    expect(screen.getByText("Kore")).toBeInTheDocument();
+    expect(screen.getByText("en-US-Standard-A")).toBeInTheDocument();
+    expect(screen.getByText("en-US-Standard-C")).toBeInTheDocument();
+  });
+
+  it("calls onPlayAll when the play-all button is clicked", async () => {
+    const onPlayAll = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ResultsList
+        referenceLabel="Kore"
+        candidateLabels={["en-US-Standard-A"]}
+        results={results}
+        onPlay={() => {}}
+        onPlayAll={onPlayAll}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /play all in sequence/i }),
+    );
+    expect(onPlayAll).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/voice-matcher/components/ResultsList.test.tsx
+++ b/frontend/src/features/voice-matcher/components/ResultsList.test.tsx
@@ -19,6 +19,7 @@ describe("ResultsList", () => {
         results={results}
         onPlay={() => {}}
         onPlayAll={() => {}}
+        isRunning={false}
       />,
     );
     expect(screen.getByText("Kore")).toBeInTheDocument();
@@ -36,11 +37,31 @@ describe("ResultsList", () => {
         results={results}
         onPlay={() => {}}
         onPlayAll={onPlayAll}
+        isRunning={false}
       />,
     );
     await user.click(
       screen.getByRole("button", { name: /play all in sequence/i }),
     );
     expect(onPlayAll).toHaveBeenCalled();
+  });
+
+  it("disables play-all while a batch is still running", () => {
+    // While synthesizing, some cards have no URL yet; playAll captures the
+    // ready URLs once, so late finishers would be skipped. Disabling until the
+    // batch settles avoids a partial play-all.
+    render(
+      <ResultsList
+        referenceLabel="Kore"
+        candidateLabels={["en-US-Standard-A"]}
+        results={{ Kore: { status: "done", url: "blob:ref" } }}
+        onPlay={() => {}}
+        onPlayAll={() => {}}
+        isRunning
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /play all in sequence/i }),
+    ).toBeDisabled();
   });
 });

--- a/frontend/src/features/voice-matcher/components/ResultsList.tsx
+++ b/frontend/src/features/voice-matcher/components/ResultsList.tsx
@@ -7,6 +7,7 @@ interface ResultsListProps {
   results: ResultMap;
   onPlay: (url: string) => void;
   onPlayAll: () => void;
+  isRunning: boolean;
 }
 
 export function ResultsList({
@@ -15,6 +16,7 @@ export function ResultsList({
   results,
   onPlay,
   onPlayAll,
+  isRunning,
 }: ResultsListProps) {
   return (
     <div className="flex flex-col gap-4">
@@ -22,8 +24,12 @@ export function ResultsList({
         <h2 className="text-lg font-medium text-gray-900">Results</h2>
         <button
           type="button"
-          className="rounded bg-blue-600 px-3 py-1 text-sm text-white"
+          className="rounded bg-blue-600 px-3 py-1 text-sm text-white disabled:opacity-40"
           onClick={onPlayAll}
+          // While the batch runs, some cards have no URL yet; playAll snapshots
+          // the ready URLs once, so late finishers would be skipped. Disable
+          // until the batch settles.
+          disabled={isRunning}
         >
           Play all in sequence
         </button>

--- a/frontend/src/features/voice-matcher/components/ResultsList.tsx
+++ b/frontend/src/features/voice-matcher/components/ResultsList.tsx
@@ -1,0 +1,65 @@
+import type { ResultMap } from "../hooks/useBatchSynthesis.ts";
+import { VoiceResultCard } from "./VoiceResultCard.tsx";
+
+interface ResultsListProps {
+  referenceLabel: string;
+  candidateLabels: string[];
+  results: ResultMap;
+  onPlay: (url: string) => void;
+  onPlayAll: () => void;
+}
+
+export function ResultsList({
+  referenceLabel,
+  candidateLabels,
+  results,
+  onPlay,
+  onPlayAll,
+}: ResultsListProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-medium text-gray-900">Results</h2>
+        <button
+          type="button"
+          className="rounded bg-blue-600 px-3 py-1 text-sm text-white"
+          onClick={onPlayAll}
+        >
+          Play all in sequence
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="text-xs font-semibold uppercase text-gray-500">
+          Reference
+        </p>
+        <VoiceResultCard
+          label={referenceLabel}
+          result={results[referenceLabel]}
+          onPlay={onPlay}
+          highlighted
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="text-xs font-semibold uppercase text-gray-500">
+          Candidates
+        </p>
+        {candidateLabels.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No Standard voices match this locale and gender.
+          </p>
+        ) : (
+          candidateLabels.map((label) => (
+            <VoiceResultCard
+              key={label}
+              label={label}
+              result={results[label]}
+              onPlay={onPlay}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/voice-matcher/components/TextInput.test.tsx
+++ b/frontend/src/features/voice-matcher/components/TextInput.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TextInput } from "./TextInput.tsx";
+
+describe("TextInput", () => {
+  it("renders the current value and calls onChange on typing", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TextInput value="" onChange={onChange} />);
+    await user.type(screen.getByLabelText("Phrase"), "hi");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("shows the provided value", () => {
+    render(<TextInput value="hello world" onChange={() => {}} />);
+    expect(screen.getByLabelText("Phrase")).toHaveValue("hello world");
+  });
+});

--- a/frontend/src/features/voice-matcher/components/TextInput.tsx
+++ b/frontend/src/features/voice-matcher/components/TextInput.tsx
@@ -1,0 +1,19 @@
+interface TextInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function TextInput({ value, onChange }: TextInputProps) {
+  return (
+    <label className="flex flex-col gap-1 text-sm text-gray-700">
+      <span>Phrase</span>
+      <textarea
+        aria-label="Phrase"
+        className="min-h-24 rounded border border-gray-300 px-2 py-1"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Enter a phrase to synthesize…"
+      />
+    </label>
+  );
+}

--- a/frontend/src/features/voice-matcher/components/VoiceResultCard.test.tsx
+++ b/frontend/src/features/voice-matcher/components/VoiceResultCard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { VoiceResultCard } from "./VoiceResultCard.tsx";
+
+describe("VoiceResultCard", () => {
+  it("shows a spinner/pending label while pending and disables play", () => {
+    render(
+      <VoiceResultCard
+        label="en-US-Standard-A"
+        result={{ status: "pending" }}
+        onPlay={() => {}}
+      />,
+    );
+    expect(screen.getByText("en-US-Standard-A")).toBeInTheDocument();
+    expect(screen.getByText(/synthesizing/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /play/i })).toBeDisabled();
+  });
+
+  it("enables play when done and calls onPlay with the url", async () => {
+    const onPlay = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <VoiceResultCard
+        label="en-US-Standard-A"
+        result={{ status: "done", url: "blob:mock-1" }}
+        onPlay={onPlay}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /play/i });
+    expect(btn).toBeEnabled();
+    await user.click(btn);
+    expect(onPlay).toHaveBeenCalledWith("blob:mock-1");
+  });
+
+  it("shows the error message when status is error", () => {
+    render(
+      <VoiceResultCard
+        label="en-US-Standard-A"
+        result={{ status: "error", error: "boom" }}
+        onPlay={() => {}}
+      />,
+    );
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /play/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/features/voice-matcher/components/VoiceResultCard.tsx
+++ b/frontend/src/features/voice-matcher/components/VoiceResultCard.tsx
@@ -1,0 +1,49 @@
+import clsx from "clsx";
+import type { SynthesisResult } from "../hooks/useBatchSynthesis.ts";
+
+interface VoiceResultCardProps {
+  label: string;
+  result: SynthesisResult | undefined;
+  onPlay: (url: string) => void;
+  highlighted?: boolean;
+}
+
+export function VoiceResultCard({
+  label,
+  result,
+  onPlay,
+  highlighted = false,
+}: VoiceResultCardProps) {
+  const status = result?.status ?? "pending";
+  const canPlay = status === "done" && result?.url !== undefined;
+
+  return (
+    <div
+      className={clsx(
+        "flex items-center justify-between gap-3 rounded border px-3 py-2",
+        highlighted ? "border-blue-400 bg-blue-50" : "border-gray-200",
+      )}
+    >
+      <span className="font-mono text-sm text-gray-800">{label}</span>
+
+      <div className="flex items-center gap-3">
+        {status === "pending" ? (
+          <span className="text-xs text-gray-500">Synthesizing…</span>
+        ) : null}
+        {status === "error" ? (
+          <span className="text-xs text-red-600">{result?.error}</span>
+        ) : null}
+        <button
+          type="button"
+          className="rounded bg-gray-800 px-3 py-1 text-xs text-white disabled:opacity-40"
+          disabled={!canPlay}
+          onClick={() => {
+            if (result?.url) onPlay(result.url);
+          }}
+        >
+          Play
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/voice-matcher/hooks/useBatchSynthesis.test.ts
+++ b/frontend/src/features/voice-matcher/hooks/useBatchSynthesis.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useBatchSynthesis,
+  type SynthesisJob,
+} from "./useBatchSynthesis.ts";
+
+let created: string[];
+let revoked: string[];
+let urlCounter: number;
+
+beforeEach(() => {
+  created = [];
+  revoked = [];
+  urlCounter = 0;
+  vi.stubGlobal("URL", {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => {
+      const url = `blob:mock-${urlCounter++}`;
+      created.push(url);
+      return url;
+    }),
+    revokeObjectURL: vi.fn((url: string) => revoked.push(url)),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function makeJob(key: string, blob = new Blob(["x"])): SynthesisJob {
+  return { key, run: vi.fn(async () => blob) };
+}
+
+describe("useBatchSynthesis", () => {
+  it("synthesizes all jobs and creates a blob URL per success", async () => {
+    const jobs = [makeJob("a"), makeJob("b"), makeJob("c")];
+    const { result } = renderHook(() => useBatchSynthesis(2));
+
+    act(() => result.current.start(jobs));
+
+    await waitFor(() =>
+      expect(
+        ["a", "b", "c"].every(
+          (k) => result.current.results[k]?.status === "done",
+        ),
+      ).toBe(true),
+    );
+    expect(created).toHaveLength(3);
+    for (const k of ["a", "b", "c"]) {
+      expect(result.current.results[k].url).toMatch(/^blob:mock-/);
+    }
+  });
+
+  it("never runs more than the concurrency limit at once", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const makeSlow = (key: string): SynthesisJob => ({
+      key,
+      run: vi.fn(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return new Blob(["x"]);
+      }),
+    });
+    const jobs = ["a", "b", "c", "d", "e"].map(makeSlow);
+    const { result } = renderHook(() => useBatchSynthesis(2));
+
+    act(() => result.current.start(jobs));
+
+    await waitFor(() =>
+      expect(
+        jobs.every((j) => result.current.results[j.key]?.status === "done"),
+      ).toBe(true),
+    );
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+  });
+
+  it("isolates a failing job — others still succeed", async () => {
+    const ok1 = makeJob("a");
+    const bad: SynthesisJob = {
+      key: "b",
+      run: vi.fn(async () => {
+        throw new Error("synth failed");
+      }),
+    };
+    const ok2 = makeJob("c");
+    const { result } = renderHook(() => useBatchSynthesis(3));
+
+    act(() => result.current.start([ok1, bad, ok2]));
+
+    await waitFor(() =>
+      expect(result.current.results.b?.status).toBe("error"),
+    );
+    expect(result.current.results.a.status).toBe("done");
+    expect(result.current.results.c.status).toBe("done");
+    expect(result.current.results.b.error).toBe("synth failed");
+  });
+
+  it("reset revokes all created blob URLs", async () => {
+    const jobs = [makeJob("a"), makeJob("b")];
+    const { result } = renderHook(() => useBatchSynthesis(2));
+
+    act(() => result.current.start(jobs));
+    await waitFor(() =>
+      expect(result.current.results.b?.status).toBe("done"),
+    );
+
+    act(() => result.current.reset());
+    expect(revoked).toEqual(expect.arrayContaining(created));
+    expect(result.current.results).toEqual({});
+  });
+});

--- a/frontend/src/features/voice-matcher/hooks/useBatchSynthesis.ts
+++ b/frontend/src/features/voice-matcher/hooks/useBatchSynthesis.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface SynthesisJob {
+  key: string;
+  run: (signal: AbortSignal) => Promise<Blob>;
+}
+
+export type ResultStatus = "pending" | "done" | "error";
+
+export interface SynthesisResult {
+  status: ResultStatus;
+  url?: string;
+  error?: string;
+}
+
+export type ResultMap = Record<string, SynthesisResult>;
+
+interface UseBatchSynthesisReturn {
+  results: ResultMap;
+  isRunning: boolean;
+  start: (jobs: SynthesisJob[]) => void;
+  reset: () => void;
+}
+
+export function useBatchSynthesis(concurrency: number): UseBatchSynthesisReturn {
+  const [results, setResults] = useState<ResultMap>({});
+  const [isRunning, setIsRunning] = useState(false);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const urlsRef = useRef<string[]>([]);
+
+  function revokeAll() {
+    for (const url of urlsRef.current) {
+      URL.revokeObjectURL(url);
+    }
+    urlsRef.current = [];
+  }
+
+  function teardown() {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    revokeAll();
+  }
+
+  function reset() {
+    teardown();
+    setResults({});
+    setIsRunning(false);
+  }
+
+  function start(jobs: SynthesisJob[]) {
+    teardown();
+
+    if (jobs.length === 0) {
+      setResults({});
+      setIsRunning(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const initial: ResultMap = {};
+    for (const job of jobs) {
+      initial[job.key] = { status: "pending" };
+    }
+    setResults(initial);
+    setIsRunning(true);
+
+    let cursor = 0;
+
+    async function worker() {
+      while (cursor < jobs.length) {
+        const job = jobs[cursor++];
+        try {
+          const blob = await job.run(controller.signal);
+          if (controller.signal.aborted) return;
+          const url = URL.createObjectURL(blob);
+          urlsRef.current.push(url);
+          setResults((prev) => ({
+            ...prev,
+            [job.key]: { status: "done", url },
+          }));
+        } catch (err: unknown) {
+          if (controller.signal.aborted) return;
+          setResults((prev) => ({
+            ...prev,
+            [job.key]: {
+              status: "error",
+              error: err instanceof Error ? err.message : "Synthesis failed",
+            },
+          }));
+        }
+      }
+    }
+
+    const pool = Array.from(
+      { length: Math.min(concurrency, jobs.length) },
+      () => worker(),
+    );
+
+    Promise.all(pool).finally(() => {
+      if (!controller.signal.aborted) {
+        setIsRunning(false);
+      }
+    });
+  }
+
+  // Cleanup on unmount: abort in-flight work and revoke any created blob URLs.
+  // Self-contained (refs only) so it needs no dependencies — mirrors
+  // features/tts/hooks/useAudioPlayback.ts.
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+        abortRef.current = null;
+      }
+      for (const url of urlsRef.current) {
+        URL.revokeObjectURL(url);
+      }
+      urlsRef.current = [];
+    };
+  }, []);
+
+  return { results, isRunning, start, reset };
+}

--- a/frontend/src/features/voice-matcher/hooks/useStandardCandidates.test.ts
+++ b/frontend/src/features/voice-matcher/hooks/useStandardCandidates.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { Voice } from "../../../types/api.ts";
+import {
+  filterStandardCandidates,
+  uniqueLocales,
+} from "./useStandardCandidates.ts";
+
+const voices: Voice[] = [
+  { id: "en-US-Standard-A", name: "en-US-Standard-A", language: "en-US", gender: "male" },
+  { id: "en-US-Standard-C", name: "en-US-Standard-C", language: "en-US", gender: "female" },
+  { id: "en-US-Standard-X", name: "en-US-Standard-X", language: "en-US", gender: "neutral" },
+  { id: "en-US-Standard-Z", name: "en-US-Standard-Z", language: "en-US" },
+  { id: "de-DE-Standard-A", name: "de-DE-Standard-A", language: "de-DE", gender: "female" },
+];
+
+describe("uniqueLocales", () => {
+  it("returns sorted unique locales", () => {
+    expect(uniqueLocales(voices)).toEqual(["de-DE", "en-US"]);
+  });
+
+  it("returns an empty array for no voices", () => {
+    expect(uniqueLocales([])).toEqual([]);
+  });
+});
+
+describe("filterStandardCandidates", () => {
+  it("keeps same-gender, neutral and undefined; excludes only the opposite gender", () => {
+    const result = filterStandardCandidates(voices, "en-US", "male");
+    expect(result.map((v) => v.id)).toEqual([
+      "en-US-Standard-A", // male
+      "en-US-Standard-X", // neutral
+      "en-US-Standard-Z", // undefined
+    ]);
+  });
+
+  it("excludes male when reference is female", () => {
+    const result = filterStandardCandidates(voices, "en-US", "female");
+    expect(result.map((v) => v.id)).toEqual([
+      "en-US-Standard-C", // female
+      "en-US-Standard-X", // neutral
+      "en-US-Standard-Z", // undefined
+    ]);
+  });
+
+  it("filters by locale", () => {
+    const result = filterStandardCandidates(voices, "de-DE", "female");
+    expect(result.map((v) => v.id)).toEqual(["de-DE-Standard-A"]);
+  });
+
+  it("returns empty when locale or gender is null", () => {
+    expect(filterStandardCandidates(voices, null, "male")).toEqual([]);
+    expect(filterStandardCandidates(voices, "en-US", null)).toEqual([]);
+  });
+});

--- a/frontend/src/features/voice-matcher/hooks/useStandardCandidates.ts
+++ b/frontend/src/features/voice-matcher/hooks/useStandardCandidates.ts
@@ -1,0 +1,44 @@
+import type { Voice } from "../../../types/api.ts";
+import { useStandardVoices } from "../api/queries.ts";
+
+export type ReferenceGender = "male" | "female";
+
+export function uniqueLocales(voices: Voice[]): string[] {
+  return [...new Set(voices.map((v) => v.language))].sort();
+}
+
+export function filterStandardCandidates(
+  voices: Voice[],
+  locale: string | null,
+  referenceGender: ReferenceGender | null,
+): Voice[] {
+  if (locale === null || referenceGender === null) {
+    return [];
+  }
+  const opposite: ReferenceGender =
+    referenceGender === "male" ? "female" : "male";
+  return voices.filter(
+    (v) => v.language === locale && v.gender !== opposite,
+  );
+}
+
+interface UseStandardCandidatesResult {
+  locales: string[];
+  candidates: Voice[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useStandardCandidates(
+  locale: string | null,
+  referenceGender: ReferenceGender | null,
+): UseStandardCandidatesResult {
+  const { data, isLoading, isError } = useStandardVoices();
+  const voices = data ?? [];
+  return {
+    locales: uniqueLocales(voices),
+    candidates: filterStandardCandidates(voices, locale, referenceGender),
+    isLoading,
+    isError,
+  };
+}

--- a/frontend/src/features/voice-matcher/lib/synthesize.test.ts
+++ b/frontend/src/features/voice-matcher/lib/synthesize.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../../lib/api-client.ts";
 import { synthesizeCandidate, synthesizeReference } from "./synthesize.ts";
 
 describe("voice-matcher synthesize", () => {
@@ -44,7 +45,7 @@ describe("voice-matcher synthesize", () => {
     });
   });
 
-  it("throws the server message on a non-ok response", async () => {
+  it("throws an ApiError preserving status and server message on a non-ok response", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ message: "boom" }), {
         status: 500,
@@ -52,8 +53,14 @@ describe("voice-matcher synthesize", () => {
       }),
     );
     const controller = new AbortController();
-    await expect(
-      synthesizeCandidate("en-US-Standard-A", "hi", controller.signal),
-    ).rejects.toThrow("boom");
+    const err = await synthesizeCandidate(
+      "en-US-Standard-A",
+      "hi",
+      controller.signal,
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+    expect((err as ApiError).message).toBe("boom");
   });
 });

--- a/frontend/src/features/voice-matcher/lib/synthesize.test.ts
+++ b/frontend/src/features/voice-matcher/lib/synthesize.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { synthesizeCandidate, synthesizeReference } from "./synthesize.ts";
+
+describe("voice-matcher synthesize", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(new Blob(["audio"], { type: "audio/wav" }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("synthesizeReference posts to gemini-tts with model and no format", async () => {
+    const controller = new AbortController();
+    await synthesizeReference("Kore", "hello", "gemini-2.5-flash-preview-tts", controller.signal);
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tts/gemini-tts/synthesize");
+    expect(JSON.parse(opts.body as string)).toEqual({
+      voiceId: "Kore",
+      text: "hello",
+      model: "gemini-2.5-flash-preview-tts",
+    });
+  });
+
+  it("synthesizeCandidate posts to google with LINEAR16 format", async () => {
+    const controller = new AbortController();
+    await synthesizeCandidate("en-US-Standard-A", "hello", controller.signal);
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tts/google/synthesize");
+    expect(JSON.parse(opts.body as string)).toEqual({
+      voiceId: "en-US-Standard-A",
+      text: "hello",
+      format: "LINEAR16",
+    });
+  });
+
+  it("throws the server message on a non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "boom" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const controller = new AbortController();
+    await expect(
+      synthesizeCandidate("en-US-Standard-A", "hi", controller.signal),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/frontend/src/features/voice-matcher/lib/synthesize.ts
+++ b/frontend/src/features/voice-matcher/lib/synthesize.ts
@@ -1,4 +1,4 @@
-import { api } from "../../../lib/api-client.ts";
+import { ApiError, api } from "../../../lib/api-client.ts";
 import {
   CANDIDATE_PROVIDER_ID,
   REFERENCE_PROVIDER_ID,
@@ -24,7 +24,7 @@ async function postSynthesize(
     } catch {
       // non-JSON error body — keep statusText
     }
-    throw new Error(message);
+    throw new ApiError(response.status, message);
   }
 
   return response.blob();

--- a/frontend/src/features/voice-matcher/lib/synthesize.ts
+++ b/frontend/src/features/voice-matcher/lib/synthesize.ts
@@ -1,0 +1,58 @@
+import { api } from "../../../lib/api-client.ts";
+import {
+  CANDIDATE_PROVIDER_ID,
+  REFERENCE_PROVIDER_ID,
+} from "../api/queries.ts";
+
+async function postSynthesize(
+  providerId: string,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<Blob> {
+  const response = await api.fetchRaw(`/tts/${providerId}/synthesize`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    let message = response.statusText;
+    try {
+      const errorBody = await response.json();
+      message = errorBody.message || message;
+    } catch {
+      // non-JSON error body — keep statusText
+    }
+    throw new Error(message);
+  }
+
+  return response.blob();
+}
+
+export function synthesizeReference(
+  voiceId: string,
+  text: string,
+  model: string,
+  signal: AbortSignal,
+): Promise<Blob> {
+  // Gemini defaults to WAV — do NOT send a format.
+  return postSynthesize(
+    REFERENCE_PROVIDER_ID,
+    { voiceId, text, model },
+    signal,
+  );
+}
+
+export function synthesizeCandidate(
+  voiceId: string,
+  text: string,
+  signal: AbortSignal,
+): Promise<Blob> {
+  // LINEAR16 -> the route maps it to audio/wav for a fair A/B with the WAV reference.
+  return postSynthesize(
+    CANDIDATE_PROVIDER_ID,
+    { voiceId, text, format: "LINEAR16" },
+    signal,
+  );
+}

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -282,15 +282,22 @@ describe("Router", () => {
         screen.getByRole("heading", { name: "Providers" }),
       ).toBeInTheDocument();
     });
+
+    it("renders Voice Matcher page at /voice-matcher", () => {
+      renderWithRouter(["/voice-matcher"]);
+      expect(
+        screen.getByRole("heading", { name: "Voice Matcher" }),
+      ).toBeInTheDocument();
+    });
   });
 
   describe("Sidebar", () => {
-    it("renders all 5 navigation links", () => {
+    it("renders all 6 navigation links", () => {
       renderWithRouter(["/datasets"]);
       const nav = screen.getByRole("navigation");
       const links = within(nav).getAllByRole("link");
 
-      expect(links).toHaveLength(5);
+      expect(links).toHaveLength(6);
       expect(nav).toContainElement(links[0]);
     });
 
@@ -301,6 +308,7 @@ describe("Router", () => {
       expect(screen.getByRole("link", { name: "Realtime" })).toBeInTheDocument();
       expect(screen.getByRole("link", { name: "Realtime Gemini" })).toBeInTheDocument();
       expect(screen.getByRole("link", { name: "Providers" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Voice Matcher" })).toBeInTheDocument();
     });
 
     it("highlights the active nav link", () => {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,7 @@ import { PromptEditor } from "./features/datasets/components/PromptEditor.tsx";
 import { GeminiRealtimePage } from "./features/realtime/components/GeminiRealtimePage.tsx";
 import { RealtimePage } from "./features/realtime/components/RealtimePage.tsx";
 import { TtsPage } from "./features/tts/components/TtsPage.tsx";
+import { VoiceMatcherPage } from "./features/voice-matcher/VoiceMatcherPage.tsx";
 import { ProvidersPage } from "./pages/ProvidersPage.tsx";
 
 export function AppRouteTree() {
@@ -20,6 +21,7 @@ export function AppRouteTree() {
         <Route path="realtime" element={<RealtimePage />} />
         <Route path="realtime-gemini" element={<GeminiRealtimePage />} />
         <Route path="providers" element={<ProvidersPage />} />
+        <Route path="voice-matcher" element={<VoiceMatcherPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary

Adds a frontend-only **Voice Matcher** page: pick a reference Gemini TTS voice + model, pick a Standard (Google) locale, enter text, then synthesize the text with the reference and with **every** same-locale / same-gender Standard voice for ear-based A/B comparison. Iteration 1 = synthesis + playback only (no automatic timbre metrics — that's backlog).

Closes #90.

## What's included

New feature `frontend/src/features/voice-matcher/` mirroring `features/tts/` (no cross-feature imports; feature-local query hooks):

- **`api/queries.ts`** — local `useStandardVoices` / `useGeminiVoices` hooks.
- **`hooks/useStandardCandidates.ts`** — filters Standard voices by selected locale + gender, excluding only the *opposite* gender (so `neutral`/unspecified voices appear for any reference). Surfaces `isLoading`/`isError`.
- **`lib/synthesize.ts`** — `synthesizeReference` (Gemini, no format → WAV) and `synthesizeCandidate` (Google, `format: "LINEAR16"` → route maps to `audio/wav` for a fair A/B). Throws shared `ApiError` preserving HTTP status.
- **`hooks/useBatchSynthesis.ts`** — concurrency-limited (3) batch synthesis, blob-URL create + revoke on reset/param-change/unmount, per-card error isolation.
- **Components** — `ReferencePicker` (model + voice selects, auto-derived gender badge), `LocaleSelector` (locales from the real Standard voice list, with loading/error states), `TextInput`, `VoiceResultCard`, `ResultsList` (highlighted reference card + candidate cards, per-card players, "play all in sequence").
- **`VoiceMatcherPage.tsx`** — composition + reset-on-param-change (revokes blobs), single-card play clears stale `onended` chaining, synth button disabled on empty text / in-flight batch.
- Route `/voice-matcher` + sidebar item; `router.test.tsx` updated for the new link.

No backend changes — existing `/tts/:providerId/voices` and `/tts/:providerId/synthesize` routes cover everything.

## Verification

- `npm run build` (backend tsc + frontend tsc -b + vite) — ✅
- `npm run lint --workspace=frontend` — ✅ exit 0, 0 warnings
- Tests — ✅ backend 465, frontend 176 (incl. new voice-matcher suites: candidate filtering, batch concurrency limit, blob create/revoke, per-card error isolation, load-error/empty states, stale-onended fix, disabled-during-batch)

Built with TDD throughout (RED → GREEN per task), plus code review, alignment check, and architectural criticism passes before this PR.

## Follow-ups (out of iteration-1 scope)

- Extract a shared audio-playback primitive to `hooks/`/`lib/` to remove blob-URL/`Audio` duplication across `features/tts` and `features/voice-matcher` (cross-feature import is disallowed, so this belongs in shared code — tracked as tech debt).
- Automatic timbre ranking (speaker-embedding + cosine), persisting the chosen Gemini↔Standard pair, `speakingRate`/`pitch` matching, and a backend `language`/`gender` voice filter — all per the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)